### PR TITLE
Use Data in JSONParser instead of Array of bytes

### DIFF
--- a/Sources/Foundation/JSONDecoder.swift
+++ b/Sources/Foundation/JSONDecoder.swift
@@ -195,7 +195,7 @@ open class JSONDecoder {
     /// - throws: An error if any value throws an error during decoding.
     open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         do {
-            var parser = JSONParser(bytes: data)
+            var parser = try JSONSerialization.createParser(with: data)
             let json = try parser.parse()
             return try JSONDecoderImpl(userInfo: self.userInfo, from: json, codingPath: [], options: self.options).unwrap(as: T.self)
         } catch let error as JSONError {

--- a/Sources/Foundation/JSONDecoder.swift
+++ b/Sources/Foundation/JSONDecoder.swift
@@ -195,7 +195,7 @@ open class JSONDecoder {
     /// - throws: An error if any value throws an error during decoding.
     open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         do {
-            var parser = JSONParser(bytes: Array(data))
+            var parser = JSONParser(bytes: data)
             let json = try parser.parse()
             return try JSONDecoderImpl(userInfo: self.userInfo, from: json, codingPath: [], options: self.options).unwrap(as: T.self)
         } catch let error as JSONError {

--- a/Sources/Foundation/JSONSerialization+Parser.swift
+++ b/Sources/Foundation/JSONSerialization+Parser.swift
@@ -29,7 +29,7 @@ internal struct JSONParser {
             }
         }
         #endif
-        
+
         // ensure only white space is remaining
         var whitespace = 0
         while let next = reader.peek(offset: whitespace) {
@@ -41,7 +41,7 @@ internal struct JSONParser {
                 throw JSONError.unexpectedCharacter(ascii: next, characterIndex: reader.readerIndex + whitespace)
             }
         }
-        
+
         return value
     }
 
@@ -107,15 +107,15 @@ internal struct JSONParser {
         default:
             break
         }
-        
+
         var array = [JSONValue]()
         array.reserveCapacity(10)
-        
+
         // parse values
         while true {
             let value = try parseValue()
             array.append(value)
-            
+
             // consume the whitespace after the value before the comma
             let ascii = try reader.consumeWhitespace()
             switch ascii {
@@ -161,7 +161,7 @@ internal struct JSONParser {
         default:
             break
         }
-        
+
         var object = [String: JSONValue]()
         object.reserveCapacity(20)
 
@@ -174,7 +174,7 @@ internal struct JSONParser {
             reader.moveReaderIndex(forwardBy: 1)
             try reader.consumeWhitespace()
             object[key] = try self.parseValue()
-            
+
             let commaOrBrace = try reader.consumeWhitespace()
             switch commaOrBrace {
             case ._closebrace:
@@ -196,11 +196,11 @@ internal struct JSONParser {
 }
 
 extension JSONParser {
-    
+
     struct DocumentReader {
         let bytes: Data
 
-        private(set) var readerIndex: Int = 0
+        private(set) var readerIndex: Int
 
         private var readableBytes: Int {
             self.bytes.endIndex - self.readerIndex
@@ -213,6 +213,7 @@ extension JSONParser {
 
         init(bytes: Data) {
             self.bytes = bytes
+            self.readerIndex = bytes.startIndex
         }
 
         subscript(bounds: Range<Int>) -> Data {
@@ -514,9 +515,9 @@ extension JSONParser {
                 return nil
             }
         }
-        
+
         // MARK: Numbers
-        
+
         private enum ControlCharacter {
             case operand
             case decimalPoint
@@ -550,7 +551,7 @@ extension JSONParser {
             }
 
             var numberchars = 1
-            
+
             // parse everything else
             while let byte = self.peek(offset: numberchars) {
                 switch byte {
@@ -623,32 +624,32 @@ extension JSONParser {
 }
 
 extension UInt8 {
-    
+
     internal static let _space = UInt8(ascii: " ")
     internal static let _return = UInt8(ascii: "\r")
     internal static let _newline = UInt8(ascii: "\n")
     internal static let _tab = UInt8(ascii: "\t")
-    
+
     internal static let _colon = UInt8(ascii: ":")
     internal static let _comma = UInt8(ascii: ",")
-    
+
     internal static let _openbrace = UInt8(ascii: "{")
     internal static let _closebrace = UInt8(ascii: "}")
-    
+
     internal static let _openbracket = UInt8(ascii: "[")
     internal static let _closebracket = UInt8(ascii: "]")
-    
+
     internal static let _quote = UInt8(ascii: "\"")
     internal static let _backslash = UInt8(ascii: "\\")
-    
+
 }
 
 extension Array where Element == UInt8 {
-    
+
     internal static let _true = [UInt8(ascii: "t"), UInt8(ascii: "r"), UInt8(ascii: "u"), UInt8(ascii: "e")]
     internal static let _false = [UInt8(ascii: "f"), UInt8(ascii: "a"), UInt8(ascii: "l"), UInt8(ascii: "s"), UInt8(ascii: "e")]
     internal static let _null = [UInt8(ascii: "n"), UInt8(ascii: "u"), UInt8(ascii: "l"), UInt8(ascii: "l")]
-    
+
 }
 
 enum JSONError: Swift.Error, Equatable {

--- a/Sources/Foundation/JSONSerialization.swift
+++ b/Sources/Foundation/JSONSerialization.swift
@@ -178,7 +178,7 @@ open class JSONSerialization : NSObject {
         return try _data(withJSONObject: value, options: opt, stream: false)
     }
 
-    private static func createParser(with data: Data) throws -> JSONParser {
+    internal static func createParser(with data: Data) throws -> JSONParser {
         let (encoding, advanceBy) = JSONSerialization.detectEncoding(data)
 
         if encoding == .utf8 {

--- a/Sources/Foundation/JSONSerialization.swift
+++ b/Sources/Foundation/JSONSerialization.swift
@@ -183,7 +183,7 @@ open class JSONSerialization : NSObject {
 
         if encoding == .utf8 {
             // we got utf8... happy path
-            var parser = JSONParser(bytes: data[advanceBy...])
+            let parser = JSONParser(bytes: data[advanceBy...])
             return parser
         }
 
@@ -191,7 +191,7 @@ open class JSONSerialization : NSObject {
             throw JSONError.cannotConvertInputDataToUTF8
         }
 
-        var parser = JSONParser(bytes: Data(utf8String.utf8))
+        let parser = JSONParser(bytes: Data(utf8String.utf8))
         return parser
     }
     

--- a/Sources/Foundation/JSONSerialization.swift
+++ b/Sources/Foundation/JSONSerialization.swift
@@ -337,7 +337,7 @@ private extension JSONSerialization {
         // If there is no BOM present, we might be able to determine the encoding based on
         // occurences of null bytes.
         if bytes.count >= 4 {
-            switch (bytes[0], bytes[1], bytes[2], bytes[3]) {
+            switch (bytes[bytes.startIndex], bytes[bytes.startIndex + 1], bytes[bytes.startIndex + 2], bytes[bytes.startIndex + 3]) {
             case (0, 0, 0, _):
                 return (.utf32BigEndian, 0)
             case (_, 0, 0, 0):
@@ -351,7 +351,7 @@ private extension JSONSerialization {
             }
         }
         else if bytes.count >= 2 {
-            switch (bytes[0], bytes[1]) {
+            switch (bytes[bytes.startIndex], bytes[bytes.startIndex + 1]) {
             case (0, _):
                 return (.utf16BigEndian, 0)
             case (_, 0):

--- a/Sources/Foundation/JSONSerialization.swift
+++ b/Sources/Foundation/JSONSerialization.swift
@@ -191,7 +191,7 @@ open class JSONSerialization : NSObject {
             throw JSONError.cannotConvertInputDataToUTF8
         }
 
-        var parser = JSONParser(bytes: utf8String.data(using: .utf8)!)
+        var parser = JSONParser(bytes: Data(utf8String.utf8))
         return parser
     }
     


### PR DESCRIPTION
The Data given to JSONDecoder may be memory mapped and convert it to Array can be memory/time inefficient. This commit avoids such coversion and always use Data to represent JSON document in JSONParser.