### PR TITLE
Do not depend on the HAVE_STRLCAT and HAVE_STRLCPY preprocessor definitions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,17 +76,7 @@ else()
 endif()
 FetchContent_MakeAvailable(SwiftFoundationICU SwiftFoundation)
 
-include(CheckSymbolExists)
 include(CheckLinkerFlag)
-
-check_symbol_exists(strlcat "string.h" HAVE_STRLCAT)
-check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
-if(HAVE_STRLCAT)
-    add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:HAVE_STRLCAT>)
-endif()
-if(HAVE_STRLCPY)
-    add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:HAVE_STRLCPY>)
-endif()
 
 check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,17 @@ else()
 endif()
 FetchContent_MakeAvailable(SwiftFoundationICU SwiftFoundation)
 
+include(CheckSymbolExists)
 include(CheckLinkerFlag)
+
+check_symbol_exists(strlcat "string.h" HAVE_STRLCAT)
+check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
+if(HAVE_STRLCAT)
+    add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:HAVE_STRLCAT>)
+endif()
+if(HAVE_STRLCPY)
+    add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:HAVE_STRLCPY>)
+endif()
 
 check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
 

--- a/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
+++ b/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
@@ -199,8 +199,14 @@ static dispatch_queue_t __ ## PREFIX ## Queue(void) {			\
     #endif
 #endif
 
-#if !TARGET_OS_MAC
-#if !HAVE_STRLCPY
+#if TARGET_OS_MAC ||                                                           \
+    (TARGET_OS_LINUX &&                                                        \
+     (defined(__GLIBC__) &&                                                    \
+          (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38)) ||      \
+      !defined(__GLIBC__)))
+// strlcat and strlcpy are available in the system
+#else
+// Define local versions of strlcpy and strlcat for glibc < 2.38
 CF_INLINE size_t
 strlcpy(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -212,9 +218,7 @@ strlcpy(char * dst, const char * src, size_t maxlen) {
     }
     return srclen;
 }
-#endif
 
-#if !HAVE_STRLCAT
 CF_INLINE size_t
 strlcat(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -228,8 +232,8 @@ strlcat(char * dst, const char * src, size_t maxlen) {
     }
     return dstlen + srclen;
 }
-#endif
-#endif // !TARGET_OS_MAC
+#endif // TARGET_OS_MAC || (TARGET_OS_LINUX && defined(__GLIBC__) && (__GLIBC__
+       // > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38)))
 
 #if TARGET_OS_WIN32
 // Compatibility with boolean.h


### PR DESCRIPTION
While checking whether the system provides the `strlcat` and `strlcpy`
functions, using an autoconf-style check to determine their availability
does not seem to be a good idea. This is because the code is also
used with SwiftPM, which does not have a similar feature test.
Instead, we should directly check the availability of these functions
in the system.

Given that `strlcpy` and `strlcat` are not standard C functions,
we should check whether the system is macOS, Linux with Bionic or
Musl libc, or glibc version 2.38 or later. This patch adds the necessary
checks in the header file so that SwiftPM can use these checks as well.

Fixes #5012