### PR TITLE
Delete CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Code of Conduct
-
-The code of conduct for this project can be found at https://swift.org/community/#code-of-conduct


### PR DESCRIPTION
preparing for migration to /swiftlang 

we have an org wide code of conduct policy set at the root .github repo of /swiftlang that all repos will adhere to. this file present at the root means there is a different process than the rest of the org.