### PR TITLE
Fix a test marked `@MainActor` but not `async`.

### DIFF
--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -410,7 +410,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         }
     }
     
-    func test_taskCopy() {
+    func test_taskCopy() async {
         let url = URL(string: "http://127.0.0.1:\(TestURLSession.serverPort)/Nepal")!
         let session = URLSession(configuration: URLSessionConfiguration.default,
                                  delegate: nil,


### PR DESCRIPTION
SPM and swift-corelibs-xctest do not support main-actor-isolated tests unless they are marked `async` because the compilation stage that finds tests is not actor-aware. This test is preventing us from merging https://github.com/swiftlang/swift-package-manager/pull/7967.