### PR TITLE
Update FileManager.swift to include bracket in save message

### DIFF
--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -151,7 +151,7 @@ extension FileManager {
             if attempt == 0 {
                 return "(A Document Being Saved By \(name))"
             } else {
-                return "(A Document Being Saved By \(name) \(attempt + 1)"
+                return "(A Document Being Saved By \(name) \(attempt + 1))"
             }
         }
         


### PR DESCRIPTION
When attempting to save a document multiple times the closing bracket was missing in the printed message   
This fixes [Issue 953](https://github.com/swiftlang/swift-foundation/issues/953)

(had some time at my hands bc am waiting for login credentials from my workplace)