### PR TITLE
[6.0.x] Add a thread-safe implementation of Process.currentDirectoryURL

### DIFF
--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -725,6 +725,7 @@ CF_EXPORT int _CFPosixSpawnFileActionsDestroy(_CFPosixSpawnFileActionsRef file_a
 CF_EXPORT void _CFPosixSpawnFileActionsDealloc(_CFPosixSpawnFileActionsRef file_actions);
 CF_EXPORT int _CFPosixSpawnFileActionsAddDup2(_CFPosixSpawnFileActionsRef file_actions, int filedes, int newfiledes);
 CF_EXPORT int _CFPosixSpawnFileActionsAddClose(_CFPosixSpawnFileActionsRef file_actions, int filedes);
+CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_actions, const char *path);
 #ifdef __cplusplus
 CF_EXPORT int _CFPosixSpawn(pid_t *_CF_RESTRICT pid, const char *_CF_RESTRICT path, _CFPosixSpawnFileActionsRef file_actions, _CFPosixSpawnAttrRef _Nullable _CF_RESTRICT attrp, char *const argv[], char *const envp[]);
 #else


### PR DESCRIPTION
posix_spawn_file_actions_addchdir_np is the official way to set the working directory of a spawned process and is supported on both macOS and glibc (Linux, etc.). This makes Process.currentDirectoryURL thread-safe, as the current approach will result in the working directory being nondeterministically assigned when spawning processes across multiple threads, using different working directories.

This already landed in main via https://github.com/swiftlang/swift-corelibs-foundation/pull/4981 (and amendment in https://github.com/swiftlang/swift-corelibs-foundation/pull/5090) and it's pretty disruptive for us so I'd like to get it into 6.0.x if possible.