### PR TITLE
[CFXMLInterface] Remove spurious include path.

### DIFF
--- a/Sources/_CFXMLInterface/CMakeLists.txt
+++ b/Sources/_CFXMLInterface/CMakeLists.txt
@@ -19,8 +19,7 @@ target_include_directories(_CFXMLInterface
         include
         ../CoreFoundation/include
     PRIVATE
-        ../CoreFoundation/internalInclude
-        /usr/include/libxml2/)
+        ../CoreFoundation/internalInclude)
 
 target_compile_options(_CFXMLInterface INTERFACE
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/../CoreFoundation/include/module.modulemap>"


### PR DESCRIPTION
The include path for libxml2 should be being set automatically by CMake because of the `target_link_libraries()` call; there is no need to add it explicitly.

Additionally, it's a really bad idea if you specify an absolute path...

rdar://137567628