### PR TITLE
Fix bounds checking error when parsing WWW-Authenticate field

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
@@ -433,7 +433,7 @@ private extension String.UnicodeScalarView.SubSequence {
     var rangeOfTokenPrefix: Range<Index>? {
         guard !isEmpty else { return nil }
         var end = startIndex
-        while self[end].isValidMessageToken {
+        while end != self.endIndex && self[end].isValidMessageToken {
             end = self.index(after: end)
         }
         guard end != startIndex else { return nil }

--- a/Tests/Foundation/TestURLProtectionSpace.swift
+++ b/Tests/Foundation/TestURLProtectionSpace.swift
@@ -203,5 +203,22 @@ class TestURLProtectionSpace : XCTestCase {
         XCTAssertEqual(param8_2_2.name, "param")
         XCTAssertEqual(param8_2_2.value, "")
     }
+
+    func test_createWithInvalidAuth() throws {
+        let headerFields1 = [
+            "Server": "Microsoft-IIS/10.0",
+            "request-id": "c71c2202-4013-4d64-9319-d40aba6bbe5c",
+            "WWW-Authenticate": "fdsfds",
+            "X-Powered-By": "ASP.NET",
+            "X-FEServer": "AM6PR0502CA0062",
+            "Date": "Sat, 04 Apr 2020 16:19:39 GMT",
+            "Content-Length": "0",
+        ]
+        let response1 = try XCTUnwrap(HTTPURLResponse(url: URL(string: "https://outlook.office365.com/Microsoft-Server-ActiveSync")!,
+                                                      statusCode: 401,
+                                                      httpVersion: "HTTP/1.1",
+                                                      headerFields: headerFields1))
+        XCTAssertNil(URLProtectionSpace.create(with: response1))
+    }
     #endif
 }


### PR DESCRIPTION
Without the fix:

```
swift test --filter TestURLProtectionSpace.test_createWithInvalidAuth
Test Suite 'Selected tests' started at 2024-10-11 21:04:24.085
Test Suite 'TestURLProtectionSpace' started at 2024-10-11 21:04:24.095
Test Case 'TestURLProtectionSpace.test_createWithInvalidAuth' started at 2024-10-11 21:04:24.095
Swift/StringIndexValidation.swift:143: Fatal error: Substring index is out of bounds

^C*** Signal 5: Backtracing from 0xffff95642744... failed ***
```

With the fix:
```
Test Suite 'Selected tests' started at 2024-10-11 21:19:30.602
Test Suite 'TestURLProtectionSpace' started at 2024-10-11 21:19:30.612
Test Case 'TestURLProtectionSpace.test_createWithInvalidAuth' started at 2024-10-11 21:19:30.612
Test Case 'TestURLProtectionSpace.test_createWithInvalidAuth' passed (0.005 seconds)
Test Suite 'TestURLProtectionSpace' passed at 2024-10-11 21:19:30.617
	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.005) seconds
Test Suite 'Selected tests' passed at 2024-10-11 21:19:30.617
	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.005) seconds
```