### PR TITLE
Fix infinite loop when force casting NSError to CocoaError

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -708,7 +708,9 @@ extension CocoaError: _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSError, result: inout CocoaError?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(NSError.self) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSError, result: inout CocoaError?) -> Bool {

--- a/Tests/Foundation/TestNSError.swift
+++ b/Tests/Foundation/TestNSError.swift
@@ -222,4 +222,10 @@ class TestCocoaError: XCTestCase {
         XCTAssertNotNil(e.underlying as? POSIXError)
         XCTAssertEqual(e.underlying as? POSIXError, POSIXError.init(.EACCES))
     }
+
+    func test_forceCast() {
+        let nsError = NSError(domain: NSCocoaErrorDomain, code: CocoaError.coderInvalidValue.rawValue)
+        let error = nsError as! CocoaError
+        XCTAssertEqual(error.errorCode, CocoaError.coderInvalidValue.rawValue)
+    }
 }


### PR DESCRIPTION
This PR addresses an infinite loop issue that occurred when force casting `NSError` to `CocoaError`. The problem arose because `_forceBridgeFromObjectiveC` was calling `_unconditionallyBridgeFromObjectiveC`, and in turn, `_unconditionallyBridgeFromObjectiveC` was calling `_forceBridgeFromObjectiveC`, causing a recursive loop.