### PR TITLE
Ensure NSLock/NSThread don't have stored properties with CoreFoundation types

### DIFF
--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -11,6 +11,10 @@
 
 #if canImport(Glibc)
 import Glibc
+
+// Favor the Glibc declarations over the CoreFoundation declarations to ensure that stored properties use types from publicly imported modules
+typealias pthread_mutex_t = Glibc.pthread_mutex_t
+typealias pthread_cond_t = Glibc.pthread_cond_t
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -15,8 +15,14 @@ import WinSDK
 
 #if canImport(Glibc)
 import Glibc
+
+// Favor the Glibc declarations over the CoreFoundation declarations to ensure that stored properties use types from publicly imported modules
+typealias pthread_t = Glibc.pthread_t
 #elseif canImport(Musl)
 import Musl
+
+// Favor the Musl declarations over the CoreFoundation declarations to ensure that stored properties use types from publicly imported modules
+typealias pthread_t = Musl.pthread_t
 #endif
 
 // WORKAROUND_SR9811


### PR DESCRIPTION
This PR attempts to resolve the `NSLock`/`NSThread` subclassing issues by ensuring that their stored properties use types from the `Glibc` module (which is a `public import`) instead of `CoreFoundation` (which is `@_implementationOnly` imported)