### PR TITLE
Ensure that NSCharacterSet always returns an NSObject on copy

### DIFF
--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -371,9 +371,9 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     
     open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
-            return _CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)
+            return _CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)._nsObject
         } else if type(of: self) == _NSCFCharacterSet.self {
-            return CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject) as Any
+            return CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)._nsObject
         } else {
             NSRequiresConcreteImplementation()
         }


### PR DESCRIPTION
Follow up to #5107, fixes an issue where an assert in the stdlib cast was failing in assertions-enabled mode.

rdar://138005684