### PR TITLE
Ensure that NSCharacterSet always returns an NSObject on copy 

### DIFF
--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -371,9 +371,9 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     
     open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
-            return _CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)
+            return _CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)._nsObject
         } else if type(of: self) == _NSCFCharacterSet.self {
-            return CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject) as Any
+            return CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)._nsObject
         } else {
             NSRequiresConcreteImplementation()
         }


### PR DESCRIPTION
(follow up to #5107), cherry-picked from #5118 for Swift 6.0

rdar://138005684
(cherry picked from commit 592f015760cc760b2298ee29d3639969b480d044)