### PR TITLE
Fix `NSLock`/`Thread` subclassing issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,15 +120,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 endif()
 
 # Precompute module triple for installation
-if(NOT SwiftFoundation_MODULE_TRIPLE)
+if(NOT SwiftFoundation_MODULE_TRIPLE OR NOT SwiftFoundation_GLIBC_MODULE_PATHS)
     set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
     if(CMAKE_Swift_COMPILER_TARGET)
         list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
     endif()
     execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
     string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
-    set(SwiftFoundation_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
-    mark_as_advanced(SwiftFoundation_MODULE_TRIPLE)
+    if (NOT SwiftFoundation_GLIBC_MODULE_PATHS)
+        string(JSON glibc_module_path_length LENGTH "${target_info_json}" "paths" "runtimeLibraryImportPaths")
+        MATH(EXPR glibc_module_path_length "${glibc_module_path_length} - 1")
+        foreach(i RANGE ${glibc_module_path_length})
+            string(JSON value GET "${target_info_json}" "paths" "runtimeLibraryImportPaths" ${i})
+            list(APPEND SwiftFoundation_GLIBC_MODULE_PATHS "${value}")
+        endforeach()
+    endif()
+    if(NOT SwiftFoundation_MODULE_TRIPLE)
+        set(SwiftFoundation_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
+        mark_as_advanced(SwiftFoundation_MODULE_TRIPLE)
+    endif()
 endif()
 
 # System dependencies
@@ -170,6 +180,10 @@ list(APPEND _Foundation_common_build_flags
     "-Wno-int-conversion"
     "-Wno-switch"
     "-fblocks")
+
+foreach(path ${SwiftFoundation_GLIBC_MODULE_PATHS})
+    list(APPEND _Foundation_common_build_flags "-I${path}")
+endforeach()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
     list(APPEND _Foundation_common_build_flags

--- a/Sources/CoreFoundation/include/CFPriv.h
+++ b/Sources/CoreFoundation/include/CFPriv.h
@@ -592,9 +592,6 @@ CF_EXPORT CFMessagePortRef _CFMessagePortCreateLocalEx(CFAllocatorRef allocator,
 #if __has_include(<unistd.h>)
 #include <unistd.h>
 #endif
-#if _POSIX_THREADS
-#include <pthread.h>
-#endif
 #include <time.h>
 
 CF_INLINE CFAbsoluteTime _CFAbsoluteTimeFromFileTimeSpec(struct timespec ts) {

--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -44,6 +44,10 @@
 #include <unistd.h>
 #endif
 #if _POSIX_THREADS
+#if __has_include(<SwiftGlibc.h>)
+// Import SwiftGlibc.h before pthread.h (when available) to ensure the compiler understands that pthread.h is not owned by CoreFoundation
+#include <SwiftGlibc.h>
+#endif
 #include <pthread.h>
 #endif
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)


### PR DESCRIPTION
Currently, `NSLock`/`Thread` cannot be subclassed due to the following (or related) issues:

```
error: cannot inherit from class 'NSLock' (compiled with Swift 6.1) because it has overridable members that could not be loaded in Swift 5.10
Could not deserialize type for 'mutex'
Caused by: module 'CoreFoundation' was not loaded
```

This is because `NSLock`/`Thread` have members whose types come from `pthread.h`. `CoreFoundation` currently imports `pthread.h` in its public headers, and this led the compiler to believe that `pthread.h` came from the `CoreFoundation` module and not the `SwiftGlibc` clang module. This results in a failure because due to the `@_implementationOnly` import, `CoreFoundation` is not loaded by clients.

To resolve this, we need to ensure the compiler realizes that `pthread.h` and the types within come from the `SwiftGlibc` clang module rather than `CoreFoundation`. To do this, we import the `SwiftGlibc.h` header file (from the `SwiftGlibc` clang module) before importing `pthread.h`. However, `SwiftGlibc.h` is not in the default header search paths so we need CMake to lookup the path for `SwiftGlibc.h` (by asking the compiler) and add the search path when building CoreFoundation. We don't need to do this for the SwiftPM build since it seems that the modules are resolved differently and we do not have this issue (which is also why we can't add a unit test for this).

Resolves https://github.com/swiftlang/swift-corelibs-foundation/issues/5108, rdar://137716518