### PR TITLE
Align fatalError messages in Objective-C bridging methods for consistency

### DIFF
--- a/Sources/Foundation/DateComponents.swift
+++ b/Sources/Foundation/DateComponents.swift
@@ -38,7 +38,7 @@ extension DateComponents : _ObjectiveCBridgeable {
     
     public static func _forceBridgeFromObjectiveC(_ dateComponents: NSDateComponents, result: inout DateComponents?) {
         if !_conditionallyBridgeFromObjectiveC(dateComponents, result: &result) {
-            fatalError("Unable to bridge \(DateComponents.self) to \(self)")
+            fatalError("Unable to bridge \(NSDateComponents.self) to \(self)")
         }
     }
     

--- a/Sources/Foundation/Notification.swift
+++ b/Sources/Foundation/Notification.swift
@@ -111,7 +111,7 @@ extension Notification : _ObjectiveCBridgeable {
     
     public static func _forceBridgeFromObjectiveC(_ x: NSNotification, result: inout Notification?) {
         if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
-            fatalError("Unable to bridge type")
+            fatalError("Unable to bridge \(NSNotification.self) to \(self)")
         }
     }
     


### PR DESCRIPTION
This PR updates fatalError messages in the bridging methods of DateComponents and Notification to maintain a consistent message format across similar methods.

These changes enhance debugging clarity and ensure a uniform error message format throughout the codebase. Although these fatalError statements are not expected to be executed in practice, having consistent and clear error messages helps maintain code readability and aids potential debugging.