### PR TITLE
Move __CFAllocatorRespectsHintZeroWhenAllocating

### DIFF
--- a/Sources/CoreFoundation/CFBase.c
+++ b/Sources/CoreFoundation/CFBase.c
@@ -790,7 +790,7 @@ void *__CFSafelyReallocateWithAllocator(CFAllocatorRef allocator, void *destinat
     return _CLANG_ANALYZER_IGNORE_NONNULL(reallocated);;
 }
 
-Boolean __CFAllocatorRespectsHintZeroWhenAllocating(CFAllocatorRef allocator) {
+CF_PRIVATE Boolean __CFAllocatorRespectsHintZeroWhenAllocating(CFAllocatorRef allocator) {
     return allocator == kCFAllocatorSystemDefault || allocator == kCFAllocatorMallocZone;
 }
 

--- a/Sources/CoreFoundation/include/ForFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForFoundationOnly.h
@@ -70,8 +70,6 @@ CF_EXPORT void *_Nonnull __CFSafelyReallocate(void * _Nullable destination, size
 CF_EXPORT void *_Nonnull __CFSafelyReallocateWithAllocator(CFAllocatorRef _Nullable, void * _Nullable destination, size_t newCapacity, CFOptionFlags options, void (^_Nullable reallocationFailureHandler)(void *_Nonnull original, bool *_Nonnull outRecovered));
 #endif
 
-Boolean __CFAllocatorRespectsHintZeroWhenAllocating(CFAllocatorRef _Nullable allocator);
-
 typedef CF_ENUM(CFOptionFlags, _CFAllocatorHint) {
     _CFAllocatorHintZeroWhenAllocating = 1
 };

--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -105,8 +105,6 @@
 
 _CF_EXPORT_SCOPE_BEGIN
 
-CF_PRIVATE Boolean __CFAllocatorRespectsHintZeroWhenAllocating(CFAllocatorRef _Nullable allocator);
-
 struct __CFSwiftObject {
     uintptr_t isa;
 };

--- a/Sources/CoreFoundation/internalInclude/CFInternal.h
+++ b/Sources/CoreFoundation/internalInclude/CFInternal.h
@@ -1057,6 +1057,8 @@ CF_INLINE CFAllocatorRef __CFGetAllocator(CFTypeRef cf) {	// !!! Use with CF typ
     return *(CFAllocatorRef *)((char *)cf - 16);
 }
 
+CF_PRIVATE Boolean __CFAllocatorRespectsHintZeroWhenAllocating(CFAllocatorRef allocator);
+
 /* !!! Avoid #importing objc.h; e.g. converting this to a .m file */
 struct __objcFastEnumerationStateEquivalent {
     unsigned long state;


### PR DESCRIPTION
Move __CFAllocatorRespectsHintZeroWhenAllocating to a CF-internal header to avoid confusion over its linkage. Resolves #5125 