### PR TITLE
[6.0.x] Fix crash when using WebSockets with URLSession.shared

### DIFF
--- a/Sources/FoundationNetworking/URLSession/WebSocket/WebSocketURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/WebSocket/WebSocketURLProtocol.swift
@@ -129,9 +129,16 @@ internal class _WebSocketURLProtocol: _HTTPURLProtocol {
         guard let t = self.task else {
             fatalError("Cannot notify")
         }
-        guard case .taskDelegate = t.session.behaviour(for: self.task!),
-              let task = self.task as? URLSessionWebSocketTask else {
-            fatalError("WebSocket internal invariant violated")
+        switch t.session.behaviour(for: t) {
+        case .noDelegate:
+            break
+        case .taskDelegate:
+            break
+        default:
+            fatalError("Unexpected behaviour for URLSessionWebSocketTask")
+        }
+        guard let task = t as? URLSessionWebSocketTask else {
+            fatalError("Cast to URLSessionWebSocketTask failed")
         }
         
         // Buffer the response message in the task


### PR DESCRIPTION
**Explanation:** Prevents a `fatalError` when using a `URLSessionWebSocketTask` from `URLSession.shared`.
**Scope:** Only impacts `URLSessionWebSocketTask`.
**Original PR:** #5128 
**Risk:** Low - Small change to not `fatalError` in a supported config.
**Testing:** Added unit test, local testing with websocket-enabled curl, swift-ci
**Reviewer:** @parkera 

Resolves #4730 for `release/6.0`