### PR TITLE
Improve CustomNSError.errorDomain calculation

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -300,7 +300,7 @@ public protocol CustomNSError : Error {
 public extension CustomNSError {
     /// Default domain of the error.
     static var errorDomain: String {
-        return String(reflecting: self)
+        return _typeName(self, qualified: true)
     }
 
     /// The error code within the given domain.


### PR DESCRIPTION
Optimized `CustomNSError.errorDomain` calculation.

`String(reflecting:)` for `Any.Type` objects eventually calls `_type(:qualified:)`. But `String(reflecting:)` call has overhead because of `as?` checks. 

All details are listed in [issue](https://github.com/swiftlang/swift-foundation/issues/1031).