### PR TITLE
Fix Dictionary ordering in TestHTTPURLResponse.test_NSCoding 

### DIFF
--- a/Tests/Foundation/TestHTTPURLResponse.swift
+++ b/Tests/Foundation/TestHTTPURLResponse.swift
@@ -236,7 +236,8 @@ class TestHTTPURLResponse: XCTestCase {
 
         //On macOS unarchived Archived then unarchived `URLResponse` is not equal.
         XCTAssertEqual(responseA.statusCode, responseB.statusCode, "Archived then unarchived http url response must be equal.")
-        XCTAssertEqual(Array(responseA.allHeaderFields.keys), Array(responseB.allHeaderFields.keys), "Archived then unarchived http url response must be equal.")
+        // Dictionary ordering is unpredictable after encoding/decoding because every Dictionary instance has its own hash table salt. Compare Sets of the keys instead.
+        XCTAssertEqual(Set(responseA.allHeaderFields.keys), Set(responseB.allHeaderFields.keys), "Archived then unarchived http url response must be equal.")
 
         for key in responseA.allHeaderFields.keys {
             XCTAssertEqual(responseA.allHeaderFields[key] as? String, responseB.allHeaderFields[key] as? String, "Archived then unarchived http url response must be equal.")


### PR DESCRIPTION
`TestHTTPURLResponse.test_NSCoding` was sometimes failing after #5019 since Dictionary ordering can be unpredictable when encoding/decoding, e.g.

```
TestFoundation/TestHTTPURLResponse.swift:239: error: TestHTTPURLResponse.test_NSCoding : XCTAssertEqual failed: ("[AnyHashable("Content-Disposition"), AnyHashable("Content-Type")]") is not equal to ("[AnyHashable("Content-Type"), AnyHashable("Content-Disposition")]") - Archived then unarchived http url response must be equal.
```

This PR makes a small change to the test to compare Sets of the keys instead.