### PR TITLE
[Windows] FileManager.enumerator(at:) default error handler should continue rather than exiting

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -322,11 +322,11 @@ extension FileManager {
         override func nextObject() -> Any? {
             func firstValidItem() -> URL? {
                 while let url = _stack.popLast() {
-                    if !FileManager.default.fileExists(atPath: url.path) {
-                        guard let handler = _errorHandler else { return nil }
-                        if !handler(url, _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [url.path])) {
+                    guard FileManager.default.fileExists(atPath: url.path) else {
+                        if let handler = _errorHandler, !handler(url, _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [url.path])) {
                             return nil
                         }
+                        continue
                     }
                     _lastReturned = url
                     return _lastReturned


### PR DESCRIPTION
On Darwin + Linux, the default error handler for `FileManager.enumerator(at:)` continues on error (and this is the documented behavior as well) however on Windows the default error handler stops enumeration at an error. This updates the Windows behavior to match the Darwin + Linux behavior.