### PR TITLE
[6.1] [Windows] FileManager.enumerator(at:) default error handler should continue rather than exiting

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -322,11 +322,11 @@ extension FileManager {
         override func nextObject() -> Any? {
             func firstValidItem() -> URL? {
                 while let url = _stack.popLast() {
-                    if !FileManager.default.fileExists(atPath: url.path) {
-                        guard let handler = _errorHandler else { return nil }
-                        if !handler(url, _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [url.path])) {
+                    guard FileManager.default.fileExists(atPath: url.path) else {
+                        if let handler = _errorHandler, !handler(url, _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [url.path])) {
                             return nil
                         }
+                        continue
                     }
                     _lastReturned = url
                     return _lastReturned


### PR DESCRIPTION
  - **Explanation**: Updates windows default behavior of `FileManager.enumerator(at:)` when continuing after an error to match that of Darwin + Linux
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Only affects this API on Windows
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: https://github.com/swiftlang/swift-corelibs-foundation/issues/5135
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift-corelibs-foundation/pull/5136
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low, it's uncommon for enumeration to hit errors (main cause is paths exceeding max path length currently) and the scope is limited
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Tested via swift-ci testing and local testing
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @compnerd 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
