### PR TITLE
Home directory for non-existent user should not fall back to /var/empty or %ALLUSERSPROFILE%

### DIFF
--- a/Tests/Foundation/TestFileManager.swift
+++ b/Tests/Foundation/TestFileManager.swift
@@ -929,8 +929,8 @@ class TestFileManager : XCTestCase {
 
     func test_homedirectoryForUser() {
         let filemanger = FileManager.default
-        XCTAssertNotNil(filemanger.homeDirectory(forUser: "someuser"))
-        XCTAssertNotNil(filemanger.homeDirectory(forUser: ""))
+        XCTAssertNil(filemanger.homeDirectory(forUser: "someuser"))
+        XCTAssertNil(filemanger.homeDirectory(forUser: ""))
         XCTAssertNotNil(filemanger.homeDirectoryForCurrentUser)
     }
     
@@ -1268,15 +1268,13 @@ class TestFileManager : XCTestCase {
         let fm = FileManager.default
 
         #if os(Windows)
-        let defaultHomeDirectory = ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]!
         let emptyFileNameError: CocoaError.Code? = .fileReadInvalidFileName
         #else
-        let defaultHomeDirectory = "/var/empty"
         let emptyFileNameError: CocoaError.Code? = nil
         #endif
 
-        XCTAssertEqual(fm.homeDirectory(forUser: ""), URL(filePath: defaultHomeDirectory, directoryHint: .isDirectory))
-        XCTAssertEqual(NSHomeDirectoryForUser(""), defaultHomeDirectory)
+        XCTAssertNil(fm.homeDirectory(forUser: ""))
+        XCTAssertNil(NSHomeDirectoryForUser(""))
 
         XCTAssertThrowsError(try fm.contentsOfDirectory(atPath: "")) {
             let code = ($0 as? CocoaError)?.code

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -1047,11 +1047,7 @@ class TestNSString: LoopbackServerTest {
             let path = NSString(string: "~\(userName)/")
             let result = path.expandingTildeInPath
           	// next assert fails in VirtualBox because home directory for unknown user resolved to /var/run/vboxadd
-            #if os(Windows)
-            XCTAssertEqual(result, ProcessInfo.processInfo.environment["ALLUSERSPROFILE"])
-            #else
-            XCTAssertEqual(result, "/var/empty", "Return copy of receiver if home directory could not be resolved.")
-            #endif
+            XCTAssertEqual(result, "~\(userName)", "Return copy of receiver if home directory could not be resolved.")
         }
     }
     


### PR DESCRIPTION
This reverts the swift-corelibs-foundation unit tests to the previous expectations to match the behavior correction in https://github.com/swiftlang/swift-foundation/pull/1072