### PR TITLE
[Musl] Add back missing autolink arguments, fix CFPosixSpawnFileActionsChdir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
+option(BUILD_FULLY_STATIC "build fully static" NO)
 
 # Optionally build tools (on by default) but only when building shared libraries
 if(BUILD_SHARED_LIBS)

--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -2283,7 +2283,7 @@ CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_act
   // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
   //  - Amazon Linux 2 (EoL mid-2025)
   return ENOSYS;
-  #elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || defined(__ANDROID__)
+  #elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || defined(__ANDROID__) || defined(__musl__)
   // Pre-standard posix_spawn_file_actions_addchdir_np version available in:
   //  - Solaris 11.3 (October 2015)
   //  - Glibc 2.29 (February 2019)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -61,7 +61,16 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend curl>")
     target_compile_options(FoundationNetworking PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
+      "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
+
+    if(BUILD_FULLY_STATIC)
+      target_compile_options(FoundationNetworking
+        PRIVATE
+          "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend crypto>"
+          "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend ssl>"
+          "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend z>")
+    endif()
+
 endif()
 
 set_target_properties(FoundationNetworking PROPERTIES

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -37,6 +37,13 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend xml2>")
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
+
+    if(BUILD_FULLY_STATIC)
+        target_compile_options(FoundationXML
+            PRIVATE
+              "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend z>")
+    endif()
+
 endif()
 
 set_target_properties(FoundationXML PROPERTIES


### PR DESCRIPTION
We need a handful more autolink arguments; these were in a previous PR, but seem to have gone missing at some point during the re-core.

Additionally, Musl has the `posix_spawn_file_actions_addchdir_np()` function rather than the non-`_np()` version.

Fixes #5089.

rdar://140914176