### PR TITLE
[6.1] Home directory for non-existent user should not fall back to /var/empty or %ALLUSERSPROFILE%

### DIFF
--- a/Tests/Foundation/TestFileManager.swift
+++ b/Tests/Foundation/TestFileManager.swift
@@ -929,8 +929,8 @@ class TestFileManager : XCTestCase {
 
     func test_homedirectoryForUser() {
         let filemanger = FileManager.default
-        XCTAssertNotNil(filemanger.homeDirectory(forUser: "someuser"))
-        XCTAssertNotNil(filemanger.homeDirectory(forUser: ""))
+        XCTAssertNil(filemanger.homeDirectory(forUser: "someuser"))
+        XCTAssertNil(filemanger.homeDirectory(forUser: ""))
         XCTAssertNotNil(filemanger.homeDirectoryForCurrentUser)
     }
     
@@ -1268,15 +1268,13 @@ class TestFileManager : XCTestCase {
         let fm = FileManager.default
 
         #if os(Windows)
-        let defaultHomeDirectory = ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]!
         let emptyFileNameError: CocoaError.Code? = .fileReadInvalidFileName
         #else
-        let defaultHomeDirectory = "/var/empty"
         let emptyFileNameError: CocoaError.Code? = nil
         #endif
 
-        XCTAssertEqual(fm.homeDirectory(forUser: ""), URL(filePath: defaultHomeDirectory, directoryHint: .isDirectory))
-        XCTAssertEqual(NSHomeDirectoryForUser(""), defaultHomeDirectory)
+        XCTAssertNil(fm.homeDirectory(forUser: ""))
+        XCTAssertNil(NSHomeDirectoryForUser(""))
 
         XCTAssertThrowsError(try fm.contentsOfDirectory(atPath: "")) {
             let code = ($0 as? CocoaError)?.code

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -1047,11 +1047,7 @@ class TestNSString: LoopbackServerTest {
             let path = NSString(string: "~\(userName)/")
             let result = path.expandingTildeInPath
           	// next assert fails in VirtualBox because home directory for unknown user resolved to /var/run/vboxadd
-            #if os(Windows)
-            XCTAssertEqual(result, ProcessInfo.processInfo.environment["ALLUSERSPROFILE"])
-            #else
-            XCTAssertEqual(result, "/var/empty", "Return copy of receiver if home directory could not be resolved.")
-            #endif
+            XCTAssertEqual(result, "~\(userName)", "Return copy of receiver if home directory could not be resolved.")
         }
     }
     


### PR DESCRIPTION


  - **Explanation**: Updates unit tests to match the new behavior of https://github.com/swiftlang/swift-foundation/pull/1073
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Only impacts unit tests
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Original PRs**: https://github.com/swiftlang/swift-corelibs-foundation/pull/5142
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Minimal - unit test only change
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: swift-ci testing, local testing
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @kperryua @jrflat @compnerd 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
