### PR TITLE
[FreeBSD] Fix FreeBSD build

### DIFF
--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -931,7 +931,7 @@ static void __CFTSDFinalize(void *arg) {
 
         // FreeBSD libthr emits debug message to stderr if there are leftover nonnull TSD after PTHREAD_DESTRUCTOR_ITERATIONS
         // On this platform, the destructor will never be called again, therefore it is unneccessary to set the TSD to CF_TSD_BAD_PTR
-        #if !defined(FreeBSD)
+        #if !defined(__FreeBSD__)
         // Now if the destructor is called again we will take the shortcut at the beginning of this function.
         __CFTSDSetSpecific(CF_TSD_BAD_PTR);
         #endif

--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -281,7 +281,7 @@ const char *_CFProcessPath(void) {
 
 #if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_BSD
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void) {
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
     return pthread_equal(pthread_self(), _CFMainPThread) != 0;
 #else
     return pthread_main_np() == 1;
@@ -928,9 +928,13 @@ static void __CFTSDFinalize(void *arg) {
 #if _POSIX_THREADS && !TARGET_OS_WASI
     if (table->destructorCount == PTHREAD_DESTRUCTOR_ITERATIONS - 1) {    // On PTHREAD_DESTRUCTOR_ITERATIONS-1 call, destroy our data
         free(table);
-        
+
+        // FreeBSD libthr emits debug message to stderr if there are leftover nonnull TSD after PTHREAD_DESTRUCTOR_ITERATIONS
+        // On this platform, the destructor will never be called again, therefore it is unneccessary to set the TSD to CF_TSD_BAD_PTR
+        #if !defined(FreeBSD)
         // Now if the destructor is called again we will take the shortcut at the beginning of this function.
         __CFTSDSetSpecific(CF_TSD_BAD_PTR);
+        #endif
         return;
     }
 #else

--- a/Sources/CoreFoundation/include/CoreFoundation.h
+++ b/Sources/CoreFoundation/include/CoreFoundation.h
@@ -74,7 +74,7 @@
 
 #include "ForSwiftFoundationOnly.h"
 
-#if TARGET_OS_OSX || TARGET_OS_IPHONE || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
+#if TARGET_OS_OSX || TARGET_OS_IPHONE || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI || TARGET_OS_BSD
 #  if !TARGET_OS_WASI
 #include "CFMessagePort.h"
 #include "CFPlugIn.h"

--- a/Sources/CoreFoundation/internalInclude/CFBundle_Internal.h
+++ b/Sources/CoreFoundation/internalInclude/CFBundle_Internal.h
@@ -431,7 +431,7 @@ CF_PRIVATE const CFStringRef _kCFBundleUseAppleLocalizationsKey;
 // The buffer must be PATH_MAX long or more.
 static bool _CFGetPathFromFileDescriptor(int fd, char *path);
 
-#if TARGET_OS_MAC || (TARGET_OS_BSD && !defined(__OpenBSD__))
+#if TARGET_OS_MAC || (TARGET_OS_BSD && !defined(__OpenBSD__) && !defined(__FreeBSD__))
 
 static bool _CFGetPathFromFileDescriptor(int fd, char *path) {
     return fcntl(fd, F_GETPATH, path) != -1;

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -89,7 +89,7 @@ extension FileManager {
             }
             urls = mountPoints(statBuf, Int(fsCount))
         }
-#elseif os(OpenBSD)
+#elseif os(OpenBSD) || os(FreeBSD)
         func mountPoints(_ statBufs: UnsafePointer<statfs>, _ fsCount: Int) -> [URL] {
             var urls: [URL] = []
 

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -316,9 +316,15 @@ extension FileManager {
             flags |= flagsToSet
             flags &= ~flagsToUnset
             
-            guard chflags(fsRep, flags) == 0 else {
+#if os(FreeBSD)
+            guard chflags(path, UInt(flags)) == 0 else {
                 throw _NSErrorWithErrno(errno, reading: false, path: path)
             }
+#else
+            guard chflags(path, flags) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: false, path: path)
+            }
+#endif
 #endif
         }
         

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -194,7 +194,7 @@ open class Host: NSObject {
                 let family = ifa_addr.pointee.sa_family
                 if family == sa_family_t(AF_INET) || family == sa_family_t(AF_INET6) {
                     let sa_len: socklen_t = socklen_t((family == sa_family_t(AF_INET6)) ? MemoryLayout<sockaddr_in6>.size : MemoryLayout<sockaddr_in>.size)
-#if os(OpenBSD)
+#if os(OpenBSD) || os(FreeBSD)
                     let hostlen = size_t(NI_MAXHOST)
 #else
                     let hostlen = socklen_t(NI_MAXHOST)
@@ -294,7 +294,7 @@ open class Host: NSObject {
             }
             var hints = addrinfo()
             hints.ai_family = PF_UNSPEC
-#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD) || canImport(Musl)
+#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD) || canImport(Musl) || os(FreeBSD)
             hints.ai_socktype = SOCK_STREAM
 #else
             hints.ai_socktype = Int32(SOCK_STREAM.rawValue)
@@ -324,7 +324,7 @@ open class Host: NSObject {
                 }
                 let sa_len: socklen_t = socklen_t((family == AF_INET6) ? MemoryLayout<sockaddr_in6>.size : MemoryLayout<sockaddr_in>.size)
                 let lookupInfo = { (content: inout [String], flags: Int32) in
-#if os(OpenBSD)
+#if os(OpenBSD) || os(FreeBSD)
                     let hostlen = size_t(NI_MAXHOST)
 #else
                     let hostlen = socklen_t(NI_MAXHOST)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -39,7 +39,7 @@ extension NSLocking {
 private typealias _MutexPointer = UnsafeMutablePointer<SRWLOCK>
 private typealias _RecursiveMutexPointer = UnsafeMutablePointer<CRITICAL_SECTION>
 private typealias _ConditionVariablePointer = UnsafeMutablePointer<CONDITION_VARIABLE>
-#elseif CYGWIN || os(OpenBSD)
+#elseif CYGWIN || os(OpenBSD) || os(FreeBSD)
 private typealias _MutexPointer = UnsafeMutablePointer<pthread_mutex_t?>
 private typealias _RecursiveMutexPointer = UnsafeMutablePointer<pthread_mutex_t?>
 private typealias _ConditionVariablePointer = UnsafeMutablePointer<pthread_cond_t?>
@@ -287,14 +287,14 @@ open class NSRecursiveLock: NSObject, NSLocking, @unchecked Sendable {
         InitializeConditionVariable(timeoutCond)
         InitializeSRWLock(timeoutMutex)
 #else
-#if CYGWIN || os(OpenBSD)
+#if CYGWIN || os(OpenBSD) || os(FreeBSD)
         var attrib : pthread_mutexattr_t? = nil
 #else
         var attrib = pthread_mutexattr_t()
 #endif
         withUnsafeMutablePointer(to: &attrib) { attrs in
             pthread_mutexattr_init(attrs)
-#if os(OpenBSD)
+#if os(OpenBSD) || os(FreeBSD)
             let type = Int32(PTHREAD_MUTEX_RECURSIVE.rawValue)
 #else
             let type = Int32(PTHREAD_MUTEX_RECURSIVE)

--- a/Sources/Foundation/NSPlatform.swift
+++ b/Sources/Foundation/NSPlatform.swift
@@ -9,7 +9,7 @@
 
 #if os(macOS) || os(iOS)
 fileprivate let _NSPageSize = Int(vm_page_size)
-#elseif os(Linux) || os(Android) || os(OpenBSD)
+#elseif os(Linux) || os(Android) || os(OpenBSD) || os(FreeBSD)
 fileprivate let _NSPageSize = Int(getpagesize())
 #elseif os(Windows)
 import WinSDK

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -107,7 +107,7 @@ fileprivate let FOUNDATION_SOCK_STREAM = SOCK_STREAM
 fileprivate let FOUNDATION_IPPROTO_TCP = IPPROTO_TCP
 #endif
 
-#if canImport(Glibc) && !os(Android) && !os(OpenBSD)
+#if canImport(Glibc) && !os(Android) && !os(OpenBSD) && !os(FreeBSD)
 import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM.rawValue)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
@@ -119,7 +119,7 @@ fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 #endif
 
-#if canImport(Glibc) && os(Android) || os(OpenBSD)
+#if canImport(Glibc) && os(Android) || os(OpenBSD) || os(FreeBSD)
 import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -779,7 +779,7 @@ open class Process: NSObject, @unchecked Sendable {
         }
 
         var taskSocketPair : [Int32] = [0, 0]
-#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD) || canImport(Musl)
+#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD) || os(FreeBSD) || canImport(Musl)
         socketpair(AF_UNIX, SOCK_STREAM, 0, &taskSocketPair)
 #else
         socketpair(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0, &taskSocketPair)
@@ -936,7 +936,7 @@ open class Process: NSObject, @unchecked Sendable {
             useFallbackChdir = false
         }
 
-#if canImport(Darwin) || os(Android) || os(OpenBSD)
+#if canImport(Darwin) || os(Android) || os(OpenBSD) || os(FreeBSD)
         var spawnAttrs: posix_spawnattr_t? = nil
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()


### PR DESCRIPTION
Various fixes to enable building on FreeBSD.

Fixed an issue that warning messages from libthr can be emitted to stderr when thread specific data is used. This is due to CoreFoundation setting the TSD to `CF_TSD_BAD_PTR` even after `PTHERAD_DESTRUCTOR_ITERATIONS` iterators of dtor calls. This causes libthr to emit a warning to stderr about left-over non-null TSD after max destructor iterations.