### PR TITLE
Add public initializer to HTTPCookieStorage

### DIFF
--- a/Sources/FoundationNetworking/HTTPCookieStorage.swift
+++ b/Sources/FoundationNetworking/HTTPCookieStorage.swift
@@ -67,6 +67,13 @@ open class HTTPCookieStorage: NSObject, @unchecked Sendable {
     private let syncQ = DispatchQueue(label: "org.swift.HTTPCookieStorage.syncQ")
 
     private let isEphemeral: Bool
+    
+    public init() {
+        _allCookies = [:]
+        cookieAcceptPolicy = .always
+        isEphemeral = true
+        super.init()
+    }
 
     private init(cookieStorageName: String, isEphemeral: Bool = false) {
         _allCookies = [:]


### PR DESCRIPTION
The Foundation [docs](https://developer.apple.com/documentation/foundation/httpcookiestorage) state that HTTPCookieStorage can be subclassed. This, however, is impossible to do with the [swift-corelibs-foundation](https://github.com/swiftlang/swift-corelibs-foundation) version since there are no publicly accessible initializers.

<img width="947" alt="subclass" src="https://github.com/user-attachments/assets/12a678c0-81bc-4a38-aa24-46e6b8c24532" />

```swift
class MyCookieStorage: HTTPCookieStorage {
    init(someParameter: String) {
        super.init() // Accessible on Darwin but not on other platforms
    }
}
```

This PR adds an initializer. It has no parameters similar to the Darwin version.
From what I can gather, when a `HTTPCookieStorage` is initialized, it's completely separate from the shared storage and only lives as long as there is a reference to it (i.e. cookies are not persisted).
