### PR TITLE
[android] Use Bionic imports instead where possible

### DIFF
--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -21,8 +21,8 @@ import WinSDK
 
 #if os(WASI)
 import WASILibc
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -11,8 +11,8 @@
 
 #if canImport(Glibc)
 import Glibc
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -22,8 +22,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // NOTE: this represents PLATFORM_PATH_STYLE

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // WORKAROUND_SR9811

--- a/Sources/Testing/Testing.swift
+++ b/Sources/Testing/Testing.swift
@@ -11,6 +11,8 @@
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #elseif os(WASI)
 import WASILibc
 #elseif canImport(CRT)

--- a/Sources/plutil/main.swift
+++ b/Sources/plutil/main.swift
@@ -15,9 +15,9 @@ import Glibc
 #elseif canImport(Musl)
 import Foundation
 import Musl
-#elseif canImport(Android)
+#elseif canImport(Bionic)
 import Foundation
-import Android
+import Bionic
 #elseif canImport(CRT)
 import Foundation
 import CRT

--- a/Sources/xdgTestHelper/main.swift
+++ b/Sources/xdgTestHelper/main.swift
@@ -19,7 +19,7 @@ import FoundationNetworking
 #endif
 #if os(Windows)
 import WinSDK
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #endif
 


### PR DESCRIPTION
@compnerd asked that we [use this narrower import instead where possible](https://github.com/swiftlang/swift-package-manager/pull/7755#discussion_r1665997808), so this pull does so and was tested natively on Android.