### PR TITLE
[6.1][Android] Get this repo building again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT SWIFT_SYSTEM_NAME)
 endif()
 
 # Don't enable WMO on Windows due to linker failures
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
     # Enable whole module optimization for release builds & incremental for debug builds
     if(POLICY CMP0157)
         set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,12 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
             "-I${DISPATCH_INCLUDE_PATH}/Block")
     endif()
 endif()
+if(ANDROID)
+  # LibXml2 looks for the Threads package, so
+  # ensure that it doesn't try to use the `-pthread`
+  # flag on Android.
+  set(CMAKE_HAVE_LIBC_PTHREAD YES)
+endif()
 find_package(LibXml2 REQUIRED)
 if(FOUNDATION_BUILD_NETWORKING)
     find_package(CURL REQUIRED)

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ if let environmentPath = Context.environment["DISPATCH_INCLUDE_PATH"] {
         .unsafeFlags([
             "-I/usr/lib/swift",
             "-I/usr/lib/swift/Block"
-        ], .when(platforms: [.linux, .android]))
+        ], .when(platforms: [.linux]))
     )
     if let sdkRoot = Context.environment["SDKROOT"] {
         dispatchIncludeFlags.append(.unsafeFlags([
@@ -245,7 +245,8 @@ let package = Package(
                 "BlockRuntime",
                 "CMakeLists.txt"
             ],
-            cSettings: coreFoundationBuildSettings
+            cSettings: coreFoundationBuildSettings,
+            linkerSettings: [.linkedLibrary("log", .when(platforms: [.android]))]
         ),
         .target(
             name: "BlocksRuntime",
@@ -262,7 +263,7 @@ let package = Package(
             name: "_CFXMLInterface",
             dependencies: [
                 "CoreFoundation",
-                .target(name: "Clibxml2", condition: .when(platforms: [.linux])),
+                .target(name: "Clibxml2", condition: .when(platforms: [.linux, .android])),
             ],
             path: "Sources/_CFXMLInterface",
             exclude: [
@@ -275,7 +276,7 @@ let package = Package(
             name: "_CFURLSessionInterface",
             dependencies: [
                 "CoreFoundation",
-                .target(name: "Clibcurl", condition: .when(platforms: [.linux])),
+                .target(name: "Clibcurl", condition: .when(platforms: [.linux, .android])),
             ],
             path: "Sources/_CFURLSessionInterface",
             exclude: [
@@ -348,7 +349,7 @@ let package = Package(
                 "FoundationNetworking",
                 "XCTest",
                 "Testing",
-                .target(name: "xdgTestHelper", condition: .when(platforms: [.linux]))
+                .target(name: "xdgTestHelper", condition: .when(platforms: [.linux, .android]))
             ],
             resources: [
                 .copy("Foundation/Resources")

--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -2283,7 +2283,7 @@ CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_act
   // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
   //  - Amazon Linux 2 (EoL mid-2025)
   return ENOSYS;
-  #elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || defined(__ANDROID__) || defined(__musl__)
+  #elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || (defined(__ANDROID__) && __ANDROID_API__ >= 34) || defined(__musl__)
   // Pre-standard posix_spawn_file_actions_addchdir_np version available in:
   //  - Solaris 11.3 (October 2015)
   //  - Glibc 2.29 (February 2019)

--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -69,6 +69,13 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <termios.h>
+#include <linux/fcntl.h>
+#ifdef __swift__
+// The linux/stat header is private in the Android modulemap.
+#pragma clang module import posix_filesystem.linux_stat
+#else
+#include <linux/stat.h>
+#endif
 #elif TARGET_OS_WASI
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
+++ b/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
@@ -109,6 +109,11 @@ typedef char * Class;
 #include <pthread.h>
 #endif
 
+#if TARGET_OS_ANDROID
+#define HAVE_STRLCPY 1
+#define HAVE_STRLCAT 1
+#endif
+
 #if TARGET_OS_WIN32
 #define BOOL WINDOWS_BOOL
 

--- a/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
+++ b/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
@@ -109,11 +109,6 @@ typedef char * Class;
 #include <pthread.h>
 #endif
 
-#if TARGET_OS_ANDROID
-#define HAVE_STRLCPY 1
-#define HAVE_STRLCAT 1
-#endif
-
 #if TARGET_OS_WIN32
 #define BOOL WINDOWS_BOOL
 
@@ -205,9 +200,9 @@ static dispatch_queue_t __ ## PREFIX ## Queue(void) {			\
 #endif
 
 // We know some things (Darwin, WASI, Glibc >= 2.38) have strlcpy/strlcat
-#if TARGET_OS_MAC || TARGET_OS_WASI                     \
-  || (defined(__GLIBC__) &&                             \
-      ((__GLIBC_MAJOR__ == 2 && __GLIBC_MINOR__ >= 38)  \
+#if TARGET_OS_MAC || TARGET_OS_WASI || TARGET_OS_ANDROID \
+  || (defined(__GLIBC__) &&                              \
+      ((__GLIBC_MAJOR__ == 2 && __GLIBC_MINOR__ >= 38)   \
        || __GLIBC_MAJOR__ > 2))
 #define HAVE_STRLCPY 1
 #define HAVE_STRLCAT 1

--- a/Sources/Foundation/CGFloat.swift
+++ b/Sources/Foundation/CGFloat.swift
@@ -7,6 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if canImport(Android)
+import Android
+#endif
+
 @frozen
 public struct CGFloat: Sendable {
 #if arch(i386) || arch(arm) || arch(wasm32)

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -34,6 +34,11 @@ import WASILibc
 fileprivate let _read = WASILibc.read(_:_:_:)
 fileprivate let _write = WASILibc.write(_:_:_:)
 fileprivate let _close = WASILibc.close(_:)
+#elseif canImport(Android)
+import Android
+fileprivate let _read = Android.read(_:_:_:)
+fileprivate let _write = Android.write(_:_:_:)
+fileprivate let _close = Android.close(_:)
 #endif
 
 #if canImport(WinSDK)
@@ -324,7 +329,7 @@ open class FileHandle : NSObject, @unchecked Sendable {
                 let data = mmap(nil, mapSize, PROT_READ, MAP_PRIVATE, _fd, 0)
                 // Swift does not currently expose MAP_FAILURE
                 if data != UnsafeMutableRawPointer(bitPattern: -1) {
-                    return NSData.NSDataReadResult(bytes: data!, length: mapSize) { buffer, length in
+                    return NSData.NSDataReadResult(bytes: data, length: mapSize) { buffer, length in
                         munmap(buffer, length)
                     }
                 }

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -7,6 +7,10 @@
 //
 #if !os(Windows)
 
+#if canImport(Android)
+import Android
+#endif
+
 #if os(Android) && (arch(i386) || arch(arm)) // struct stat.st_mode is UInt32
 internal func &(left: UInt32, right: mode_t) -> mode_t {
     return mode_t(left) & right
@@ -351,7 +355,14 @@ extension FileManager {
                     defer { ps.deallocate() }
                     ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
                     ps.advanced(by: 1).initialize(to: nil)
-                    return fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT, nil)
+                    return ps.withMemoryRebound(to: UnsafeMutablePointer<CChar>.self, capacity: 2) { rebound_ps in
+#if canImport(Android)
+                        let arg = rebound_ps
+#else
+                        let arg = ps
+#endif
+                        return fts_open(arg, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT, nil)
+                    }
                 }
                 if _stream == nil {
                     throw _NSErrorWithErrno(errno, reading: true, url: url)
@@ -398,13 +409,13 @@ extension FileManager {
 
                 _current = fts_read(stream)
                 while let current = _current {
-                    let filename = FileManager.default.string(withFileSystemRepresentation: current.pointee.fts_path, length: Int(current.pointee.fts_pathlen))
+                    let filename = FileManager.default.string(withFileSystemRepresentation: current.pointee.fts_path!, length: Int(current.pointee.fts_pathlen))
 
                     switch Int32(current.pointee.fts_info) {
                         case FTS_D:
                             let (showFile, skipDescendants) = match(filename: filename, to: _options, isDir: true)
                             if skipDescendants {
-                                fts_set(_stream, _current, FTS_SKIP)
+                                fts_set(stream, _current!, FTS_SKIP)
                             }
                             if showFile {
                                  return URL(fileURLWithPath: filename, isDirectory: true)
@@ -578,7 +589,7 @@ extension FileManager {
             let finalErrno = originalItemURL.withUnsafeFileSystemRepresentation { (originalFS) -> Int32? in
                 return newItemURL.withUnsafeFileSystemRepresentation { (newItemFS) -> Int32? in
                     // This is an atomic operation in many OSes, but is not guaranteed to be atomic by the standard.
-                    if rename(newItemFS, originalFS) == 0 {
+                    if rename(newItemFS!, originalFS!) == 0 {
                         return nil
                     } else {
                         return errno

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -408,7 +408,7 @@ extension FileManager {
                         case FTS_D:
                             let (showFile, skipDescendants) = match(filename: filename, to: _options, isDir: true)
                             if skipDescendants {
-                                fts_set(stream, _current!, FTS_SKIP)
+                                fts_set(stream, current, FTS_SKIP)
                             }
                             if showFile {
                                  return URL(fileURLWithPath: filename, isDirectory: true)

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -355,14 +355,7 @@ extension FileManager {
                     defer { ps.deallocate() }
                     ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
                     ps.advanced(by: 1).initialize(to: nil)
-                    return ps.withMemoryRebound(to: UnsafeMutablePointer<CChar>.self, capacity: 2) { rebound_ps in
-#if canImport(Android)
-                        let arg = rebound_ps
-#else
-                        let arg = ps
-#endif
-                        return fts_open(arg, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT, nil)
-                    }
+                    return fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT, nil)
                 }
                 if _stream == nil {
                     throw _NSErrorWithErrno(errno, reading: true, url: url)

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -21,8 +21,8 @@ import WinSDK
 
 #if os(WASI)
 import WASILibc
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -21,6 +21,8 @@ import WinSDK
 
 #if os(WASI)
 import WASILibc
+#elseif canImport(Android)
+import Android
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -12,8 +12,9 @@
 import WinSDK
 #endif
 
-#if os(Android)
-    // Android Glibc differs a little with respect to the Linux Glibc.
+#if canImport(Android)
+    import Android
+    // Android Bionic differs a little with respect to the Linux Glibc.
 
     // IFF_LOOPBACK is part of the enumeration net_device_flags, which needs to
     // convert to UInt32.
@@ -24,8 +25,8 @@ import WinSDK
     }
 
     // getnameinfo uses size_t for its 4th and 6th arguments.
-    private func getnameinfo(_ addr: UnsafePointer<sockaddr>?, _ addrlen: socklen_t, _ host: UnsafeMutablePointer<Int8>?, _ hostlen: socklen_t, _ serv: UnsafeMutablePointer<Int8>?, _ servlen: socklen_t, _ flags: Int32) -> Int32 {
-        return Glibc.getnameinfo(addr, addrlen, host, Int(hostlen), serv, Int(servlen), flags)
+    private func getnameinfo(_ addr: UnsafePointer<sockaddr>, _ addrlen: socklen_t, _ host: UnsafeMutablePointer<Int8>?, _ hostlen: socklen_t, _ serv: UnsafeMutablePointer<Int8>?, _ servlen: socklen_t, _ flags: Int32) -> Int32 {
+        return Android.getnameinfo(addr, addrlen, host, Int(hostlen), serv, Int(servlen), flags)
     }
 
     // getifaddrs and freeifaddrs are not available in Android 6.0 or earlier, so call these functions dynamically.

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -11,6 +11,9 @@
 #if !os(WASI)
 import Dispatch
 #endif
+#if canImport(Android)
+import Android
+#endif
 
 extension NSData {
     public typealias ReadingOptions = Data.ReadingOptions
@@ -469,6 +472,8 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             let createMode = Int(Musl.S_IRUSR) | Int(Musl.S_IWUSR) | Int(Musl.S_IRGRP) | Int(Musl.S_IWGRP) | Int(Musl.S_IROTH) | Int(Musl.S_IWOTH)
 #elseif canImport(WASILibc)
             let createMode = Int(WASILibc.S_IRUSR) | Int(WASILibc.S_IWUSR) | Int(WASILibc.S_IRGRP) | Int(WASILibc.S_IWGRP) | Int(WASILibc.S_IROTH) | Int(WASILibc.S_IWOTH)
+#elseif canImport(Android)
+            let createMode = Int(Android.S_IRUSR) | Int(Android.S_IWUSR) | Int(Android.S_IRGRP) | Int(Android.S_IWGRP) | Int(Android.S_IROTH) | Int(Android.S_IWOTH)
 #endif
             guard let fh = FileHandle(path: path, flags: flags, createMode: createMode) else {
                 throw _NSErrorWithErrno(errno, reading: false, path: path)

--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -16,6 +16,8 @@ import Darwin
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif canImport(Android)
+import Android
 #endif
 
 @_implementationOnly import CoreFoundation

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -11,6 +11,8 @@
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -11,8 +11,8 @@
 
 #if canImport(Glibc)
 import Glibc
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -10,6 +10,8 @@
 @_implementationOnly import CoreFoundation
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #elseif os(WASI)
 import WASILibc
 #endif

--- a/Sources/Foundation/NSPlatform.swift
+++ b/Sources/Foundation/NSPlatform.swift
@@ -10,6 +10,9 @@
 #if os(macOS) || os(iOS)
 fileprivate let _NSPageSize = Int(vm_page_size)
 #elseif os(Linux) || os(Android) || os(OpenBSD)
+#if canImport(Android)
+import Android
+#endif
 fileprivate let _NSPageSize = Int(getpagesize())
 #elseif os(Windows)
 import WinSDK

--- a/Sources/Foundation/NSSwiftRuntime.swift
+++ b/Sources/Foundation/NSSwiftRuntime.swift
@@ -19,6 +19,8 @@ internal import Synchronization
 @_exported import Glibc
 #elseif canImport(Musl)
 @_exported import Musl
+#elseif canImport(Bionic)
+@_exported import Bionic
 #elseif os(WASI)
 @_exported import WASILibc
 #elseif os(Windows)

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -22,8 +22,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // NOTE: this represents PLATFORM_PATH_STYLE

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -22,6 +22,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 // NOTE: this represents PLATFORM_PATH_STYLE

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -107,7 +107,7 @@ fileprivate let FOUNDATION_SOCK_STREAM = SOCK_STREAM
 fileprivate let FOUNDATION_IPPROTO_TCP = IPPROTO_TCP
 #endif
 
-#if canImport(Glibc) && !os(Android) && !os(OpenBSD)
+#if canImport(Glibc) && !os(OpenBSD)
 import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM.rawValue)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
@@ -119,14 +119,19 @@ fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 #endif
 
-#if canImport(Glibc) && os(Android) || os(OpenBSD)
+#if canImport(Glibc) || os(OpenBSD)
 import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 fileprivate let INADDR_ANY: in_addr_t = 0
-#if os(OpenBSD)
 fileprivate let INADDR_LOOPBACK = 0x7f000001
 #endif
+
+#if canImport(Android)
+import Android
+fileprivate let FOUNDATION_SOCK_STREAM = Int32(Android.SOCK_STREAM)
+fileprivate let FOUNDATION_IPPROTO_TCP = Int32(Android.IPPROTO_TCP)
+fileprivate let INADDR_ANY: in_addr_t = 0
 #endif
 
 

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -119,7 +119,7 @@ fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 #endif
 
-#if canImport(Glibc) || os(OpenBSD)
+#if canImport(Glibc) && os(OpenBSD)
 import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -18,6 +18,8 @@ import struct WinSDK.HANDLE
 
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Android)
+import Android
 #endif
 
 internal import Synchronization
@@ -940,6 +942,13 @@ open class Process: NSObject, @unchecked Sendable {
         var spawnAttrs: posix_spawnattr_t? = nil
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
+#endif
+#if os(Android)
+        guard var spawnAttrs else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [
+                    NSURLErrorKey:self.executableURL!
+            ])
+        }
 #endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // WORKAROUND_SR9811

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -17,6 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 // WORKAROUND_SR9811

--- a/Sources/FoundationNetworking/HTTPCookie.swift
+++ b/Sources/FoundationNetworking/HTTPCookie.swift
@@ -15,6 +15,8 @@ import Foundation
 
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable, Sendable {

--- a/Sources/Testing/Testing.swift
+++ b/Sources/Testing/Testing.swift
@@ -11,6 +11,8 @@
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #elseif os(WASI)
 import WASILibc
 #elseif canImport(CRT)

--- a/Sources/plutil/main.swift
+++ b/Sources/plutil/main.swift
@@ -15,9 +15,9 @@ import Glibc
 #elseif canImport(Musl)
 import Foundation
 import Musl
-#elseif canImport(Android)
+#elseif canImport(Bionic)
 import Foundation
-import Android
+import Bionic
 #elseif canImport(CRT)
 import Foundation
 import CRT

--- a/Sources/plutil/main.swift
+++ b/Sources/plutil/main.swift
@@ -15,6 +15,9 @@ import Glibc
 #elseif canImport(Musl)
 import Foundation
 import Musl
+#elseif canImport(Android)
+import Foundation
+import Android
 #elseif canImport(CRT)
 import Foundation
 import CRT

--- a/Sources/xdgTestHelper/main.swift
+++ b/Sources/xdgTestHelper/main.swift
@@ -19,6 +19,8 @@ import FoundationNetworking
 #endif
 #if os(Windows)
 import WinSDK
+#elseif os(Android)
+import Android
 #endif
 
 enum HelperCheckStatus : Int32 {

--- a/Sources/xdgTestHelper/main.swift
+++ b/Sources/xdgTestHelper/main.swift
@@ -19,7 +19,7 @@ import FoundationNetworking
 #endif
 #if os(Windows)
 import WinSDK
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #endif
 

--- a/Tests/Foundation/FTPServer.swift
+++ b/Tests/Foundation/FTPServer.swift
@@ -15,6 +15,8 @@ import Dispatch
     import Glibc
 #elseif canImport(Darwin)
     import Darwin
+#elseif canImport(Android)
+    import Android
 #endif
 
 final class ServerSemaphore : Sendable {

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -21,6 +21,8 @@ import Dispatch
     import Darwin
 #elseif canImport(Glibc)
     import Glibc
+#elseif canImport(Android)
+    import Android
 #endif
 
 #if !os(Windows)

--- a/Tests/Foundation/TestFileHandle.swift
+++ b/Tests/Foundation/TestFileHandle.swift
@@ -19,6 +19,8 @@
 import Dispatch
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 class TestFileHandle : XCTestCase {
@@ -111,7 +113,7 @@ class TestFileHandle : XCTestCase {
 #else
         var fds: [Int32] = [-1, -1]
         fds.withUnsafeMutableBufferPointer { (pointer) -> Void in
-            pipe(pointer.baseAddress)
+            pipe(pointer.baseAddress!)
         }
         
         close(fds[1])

--- a/Tests/Foundation/TestNSData.swift
+++ b/Tests/Foundation/TestNSData.swift
@@ -10,6 +10,10 @@
 import XCTest
 @testable import Foundation
 
+#if canImport(Android)
+import Android
+#endif
+
 class TestNSData: XCTestCase {
     
     class AllOnesImmutableData : NSData {
@@ -213,6 +217,8 @@ class TestNSData: XCTestCase {
                 let permission = try fileManager.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int
 #if canImport(Darwin)
                 let expected = Int(S_IRUSR) | Int(S_IWUSR) | Int(S_IRGRP) | Int(S_IWGRP) | Int(S_IROTH) | Int(S_IWOTH)
+#elseif canImport(Android)
+                let expected = Int(Android.S_IRUSR) | Int(Android.S_IWUSR) | Int(Android.S_IRGRP) | Int(Android.S_IWGRP) | Int(Android.S_IROTH) | Int(Android.S_IWOTH)
 #else
                 let expected = Int(Glibc.S_IRUSR) | Int(Glibc.S_IWUSR) | Int(Glibc.S_IRGRP) | Int(Glibc.S_IWGRP) | Int(Glibc.S_IROTH) | Int(Glibc.S_IWOTH)
 #endif
@@ -236,6 +242,8 @@ class TestNSData: XCTestCase {
                 let permission = try fileManager.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int
 #if canImport(Darwin)
                 let expected = Int(S_IRUSR) | Int(S_IWUSR) | Int(S_IRGRP) | Int(S_IWGRP) | Int(S_IROTH) | Int(S_IWOTH)
+#elseif canImport(Android)
+                let expected = Int(Android.S_IRUSR) | Int(Android.S_IWUSR) | Int(Android.S_IRGRP) | Int(Android.S_IWGRP) | Int(Android.S_IROTH) | Int(Android.S_IWOTH)
 #else
                 let expected = Int(Glibc.S_IRUSR) | Int(Glibc.S_IWUSR) | Int(Glibc.S_IRGRP) | Int(Glibc.S_IWGRP) | Int(Glibc.S_IROTH) | Int(Glibc.S_IWOTH)
 #endif

--- a/Tests/Foundation/TestProcess.swift
+++ b/Tests/Foundation/TestProcess.swift
@@ -8,6 +8,9 @@
 //
 
 import Synchronization
+#if canImport(Android)
+import Android
+#endif
 
 class TestProcess : XCTestCase {
     

--- a/Tests/Foundation/TestSocketPort.swift
+++ b/Tests/Foundation/TestSocketPort.swift
@@ -8,6 +8,8 @@
 //
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 class TestPortDelegateWithBlock: NSObject, PortDelegate {

--- a/Tests/Foundation/TestTimeZone.swift
+++ b/Tests/Foundation/TestTimeZone.swift
@@ -164,7 +164,7 @@ class TestTimeZone: XCTestCase {
         var lt = tm()
         localtime_r(&t, &lt)
         let zoneName = NSTimeZone.system.abbreviation() ?? "Invalid Abbreviation"
-        let expectedName = String(cString: lt.tm_zone, encoding: .ascii) ?? "Invalid Zone"
+        let expectedName = String(cString: lt.tm_zone!, encoding: .ascii) ?? "Invalid Zone"
         XCTAssertEqual(zoneName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(zoneName)\"")
     }
 #endif

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -7,6 +7,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if canImport(Android)
+import Android
+#endif
+
 let kURLTestParsingTestsKey = "ParsingTests"
 
 let kURLTestTitleKey = "In-Title"


### PR DESCRIPTION
__Explanation:__ These pulls get this repo building again with the new Android overlay, swiftlang/swift#72161.

__Scope:__ Mostly just adds imports and other Android-specific dependencies, along with some force unwraps because Bionic added nullability annotations.

__Issue:__ None

__Original PRs:__ #5024, #5144, #5149

__Risk:__ low

__Testing:__ Passed all CI on trunk and [I've been running it through my Android CI for months now](https://github.com/finagolfin/swift-android-sdk/blob/da5932236ebde8720f947ff0bf3a2f8ba75dddf8/swift-android-foundation-devel.patch)

__Reviewer:__ @compnerd @jmschonfeld

@hyp, all this is missing is your fix for the nullability annotation in `Process.swift` that you plan to submit, and this repo works on Android again.