### PR TITLE
Check for environment XCTEST_MEASURE_MAX_STDDEV for maxRelativeStandardDeviation

### DIFF
--- a/Sources/XCTest/Private/WallClockTimeMetric.swift
+++ b/Sources/XCTest/Private/WallClockTimeMetric.swift
@@ -30,7 +30,7 @@ internal final class WallClockTimeMetric: PerformanceMetric {
         measurements.append(stopTime-startTime)
     }
 
-    private let maxRelativeStandardDeviation = 10.0
+    private let maxRelativeStandardDeviation = ProcessInfo.processInfo.environment["XCTEST_MEASURE_MAX_STDDEV"].flatMap({ Double($0) }) ?? 10.0
     private let standardDeviationNegligibilityThreshold = 0.1
 
     func calculateResults() -> String {


### PR DESCRIPTION
The `XCTest.measure` currently uses 10.0 as the hardwired `maxRelativeStandardDeviation`, which can lead to test failures where a test is expected to have a high standard deviation:

```
PerformanceTests.swift:90: Test Case 'PerformanceTests.testUsingLoadWithUTF16' measured [Time, seconds] average: 0.884, relative standard deviation: 47.026%, values: [1.063468, 1.418311, 1.400721, 1.412482, 0.927719, 0.639287, 0.497485, 0.438305, 0.601177, 0.436784], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: 10.000%, maxStandardDeviation: 0.100
PerformanceTests.swift:90: error: PerformanceTests.testUsingLoadWithUTF16 : failed: The relative standard deviation of the measurements is 47.026% which is higher than the max allowed of 10.000%.
```

This PR adds a check for the environment variable `XCTEST_MEASURE_MAX_STDDEV`, which it will use as the default maximum if it is set. Otherwise, it will fall back to 10%.
