### PR TITLE
[6.1] Fix race condition in __CFStringGetEightBitStringEncoding

### DIFF
--- a/Sources/CoreFoundation/include/ForFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForFoundationOnly.h
@@ -287,8 +287,11 @@ CF_EXPORT CFStringEncoding __CFDefaultEightBitStringEncoding;
 CF_EXPORT CFStringEncoding __CFStringComputeEightBitStringEncoding(void);
 
 CF_INLINE CFStringEncoding __CFStringGetEightBitStringEncoding(void) {
-    if (__CFDefaultEightBitStringEncoding == kCFStringEncodingInvalidId) __CFStringComputeEightBitStringEncoding();
-    return __CFDefaultEightBitStringEncoding;
+    if (__CFDefaultEightBitStringEncoding == kCFStringEncodingInvalidId) {
+        return __CFStringComputeEightBitStringEncoding();
+    } else {
+        return __CFDefaultEightBitStringEncoding;
+    }
 }
 
 enum {


### PR DESCRIPTION
  - **Explanation**: Fixes a small behavior issue caused by a race condition in `__CFStringGetEightBitStringEncoding`
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Impacts many of the low-level `CFString` functions that use CoreFoundation's "eight bit" string encoding
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: https://github.com/swiftlang/swift-corelibs-foundation/issues/5152
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift-corelibs-foundation/pull/5155
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Medium - this is a low level function that is called from a lot of places in CoreFoundation, but the change is very small and is not supposed to change behavior here aside from the window of the race condition.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Local testing at desk
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @parkera 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
