### PR TITLE
Fix OpenBSD clause.

### DIFF
--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -2287,6 +2287,10 @@ CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_act
   // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
   //  - Amazon Linux 2 (EoL mid-2025)
   return ENOSYS;
+  #elif defined(__OpenBSD__)
+  // Currently missing as of:
+  //  - OpenBSD 7.5 (April 2024)
+  return ENOSYS;
   #elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || (defined(__ANDROID__) && __ANDROID_API__ >= 34) || defined(__musl__)
   // Pre-standard posix_spawn_file_actions_addchdir_np version available in:
   //  - Solaris 11.3 (October 2015)
@@ -2300,8 +2304,6 @@ CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_act
   // Standardized posix_spawn_file_actions_addchdir version (POSIX.1-2024, June 2024) available in:
   //  - Solaris 11.4 (August 2018)
   //  - NetBSD 10.0 (March 2024)
-  // Currently missing as of:
-  //  - OpenBSD 7.5 (April 2024)
   //  - QNX 8 (December 2023)
   return posix_spawn_file_actions_addchdir((posix_spawn_file_actions_t *)file_actions, path);
   #endif


### PR DESCRIPTION
OpenBSD, as the comment string in _CFPosixSpawnFileActionsChdir says, doesn't have posix_spawn_file_actions_addchdir. Therefore, don't link against it; just return ENOSYS like other similarly situated platforms do.