### PR TITLE
[DON'T MERGE] Temporarily set CMake policy CMP0157 to OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 if(POLICY CMP0157)
     # New Swift build model: improved incremental build performance and LSP support
-    cmake_policy(SET CMP0157 NEW)
+    cmake_policy(SET CMP0157 OLD)
 endif()
 
 if (NOT DEFINED CMAKE_C_COMPILER)


### PR DESCRIPTION
We need the old setting as long as we use Swift's legacy driver on Windows. This is a workaround for cross-compiling the Swift Runtime to Android in https://github.com/swiftlang/swift/pull/79185. It's not supposed to land.