### PR TITLE
Ensure URLSessionDataTask response is not dropped

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -224,7 +224,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
             failWith(error: error!, request: request)
             return
         }
-        guard case .transferInProgress(let ts) = internalState else {
+        guard case .transferInProgress(var ts) = internalState else {
             fatalError("Transfer completed, but it wasn't in progress.")
         }
         guard let request = task?.currentRequest else {
@@ -232,8 +232,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         }
 
         if let response = task?.response {
-            var transferState = ts
-            transferState.response = response
+            ts.response = response
         }
 
         guard let response = ts.response else {


### PR DESCRIPTION
This code seems to have been attempting to resolve the completed response at the end of the transfer, but it was creating a local copy and mutating that instead of mutating the transfer state we're currently looking at. This seems to happen when a header is truncated? I'm not exactly sure, but this code looked incorrect on inspection.

Still testing this fix locally.

This should fix #4052 