### PR TITLE
always @preconcurrency import Glibc/Musl

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -20,12 +20,12 @@ fileprivate let _read = Darwin.read(_:_:_:)
 fileprivate let _write = Darwin.write(_:_:_:)
 fileprivate let _close = Darwin.close(_:)
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 fileprivate let _read = Glibc.read(_:_:_:)
 fileprivate let _write = Glibc.write(_:_:_:)
 fileprivate let _close = Glibc.close(_:)
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 fileprivate let _read = Musl.read(_:_:_:)
 fileprivate let _write = Musl.write(_:_:_:)
 fileprivate let _close = Musl.close(_:)

--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -13,7 +13,7 @@
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(CRT)
 import CRT
 #elseif canImport(Android)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -10,7 +10,7 @@
 @_implementationOnly import CoreFoundation
 
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Bionic)
 import Bionic
 #endif

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -19,9 +19,9 @@ internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
 import Bionic
 #endif

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -108,19 +108,19 @@ fileprivate let FOUNDATION_IPPROTO_TCP = IPPROTO_TCP
 #endif
 
 #if canImport(Glibc) && !os(OpenBSD) && !os(FreeBSD)
-import Glibc
+@preconcurrency import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM.rawValue)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 #endif
 
 #if canImport(Musl)
-import Musl
+@preconcurrency import Musl
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 #endif
 
 #if canImport(Glibc) && (os(OpenBSD) || os(FreeBSD))
-import Glibc
+@preconcurrency import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 fileprivate let INADDR_ANY: in_addr_t = 0

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -14,9 +14,9 @@ import WinSDK
 #endif
 
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
 import Bionic
 #endif

--- a/Sources/Testing/Testing.swift
+++ b/Sources/Testing/Testing.swift
@@ -8,9 +8,9 @@
 //
 
 #if canImport(Glibc)
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
 import Bionic
 #elseif os(WASI)

--- a/Sources/plutil/main.swift
+++ b/Sources/plutil/main.swift
@@ -11,10 +11,10 @@ import Darwin
 import SwiftFoundation
 #elseif canImport(Glibc)
 import Foundation
-import Glibc
+@preconcurrency import Glibc
 #elseif canImport(Musl)
 import Foundation
-import Musl
+@preconcurrency import Musl
 #elseif canImport(Bionic)
 import Foundation
 import Bionic


### PR DESCRIPTION
Related issues:
- https://github.com/swiftlang/swift-format/issues/933
- https://github.com/swiftlang/swift/issues/79414

I've got a working program

```
@preconcurrency import Glibc
import Foundation

await Task {
  _ = fputs("hello\n", stderr)
}.value
```

but alas, if `swift-format` reformats it, it makes it (note that the two imports are reordered)

```
import Foundation
@preconcurrency import Glibc

await Task {
  _ = fputs("hello\n", stderr)
}.value
```

which unfortunately doesn't compile

```
$ swift format --in-place test.swift && swiftc -swift-version 6 test.swift && echo OK
test.swift:5:24: error: reference to var 'stderr' is not concurrency-safe because it involves shared mutable state
3 | 
4 | await Task {
5 |   _ = fputs("hello\n", stderr)
  |                        `- error: reference to var 'stderr' is not concurrency-safe because it involves shared mutable state
6 | }.value
7 | 

SwiftGlibc.stderr:1:12: note: var declared here
1 | public var stderr: UnsafeMutablePointer<FILE>!
  |            `- note: var declared here
```

the problem is that `Foundation` imports `Glibc`/`Musl` but doesn't mark them `@preconcurrency`.