### PR TITLE
Remove incorrect `guard` check for Android

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -943,13 +943,6 @@ open class Process: NSObject, @unchecked Sendable {
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
 #endif
-#if os(Android)
-        guard var spawnAttrs else {
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [
-                    NSURLErrorKey:self.executableURL!
-            ])
-        }
-#endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
 #if canImport(Darwin)


### PR DESCRIPTION
This was added a couple months ago and [when I pointed out it will fail, I was told it would be fixed by some upstream changes and here later](https://github.com/swiftlang/swift-corelibs-foundation/pull/5024#discussion_r1881514022). I haven't heard anything in that comment thread since, so let's at least get this fixed in trunk and 6.1 for now, and we can adjust to Bionic upstream whenever that change is in.

@hyp, let me know if you're okay with just fixing this for now, as [I currently have to do on my Android CI](https://github.com/finagolfin/swift-android-sdk/blob/903ae7c96e71a405911a85c4d98ac627530c78f9/swift-android-foundation-except-release.patch#L33).