### PR TITLE
[6.1] Remove incorrect `guard` check for Android (#5171)

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -943,13 +943,6 @@ open class Process: NSObject, @unchecked Sendable {
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
 #endif
-#if os(Android)
-        guard var spawnAttrs else {
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [
-                    NSURLErrorKey:self.executableURL!
-            ])
-        }
-#endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
 #if canImport(Darwin)


### PR DESCRIPTION
__Explanation:__ This `guard` check currently always fails on Android because `spawnAttrs` is set to `nil` on Android just two lines above. There was [some talk of making changes to the Android NDK upstream or nullability annotations instead by @hyp a couple months ago](https://github.com/swiftlang/swift-corelibs-foundation/pull/5024#discussion_r1881514022), which is why we left this in temporarily, but nothing came of it and he hasn't responded in months, so let's just fix this for now.

__Scope:__ Only affects Android

__Issue:__ None

__Original PR:__ #5171

__Risk:__ None

__Testing:__ I apply [this patch on my Android CI for the last couple months](https://github.com/finagolfin/swift-android-sdk/commit/903ae7c96e71a405911a85c4d98ac627530c78f9#diff-c0556429517b8d4c11433e9f45f106cbf88de41f9047e6d17de1ee164916a9e1R33), works well.

__Reviewer:__ @hyp

@itingliu, mind reviewing?