### PR TITLE
Revert "Remove incorrect `guard` check for Android"

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -943,6 +943,13 @@ open class Process: NSObject, @unchecked Sendable {
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
 #endif
+#if os(Android)
+        guard var spawnAttrs else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [
+                    NSURLErrorKey:self.executableURL!
+            ])
+        }
+#endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
 #if canImport(Darwin)


### PR DESCRIPTION
Reverts swiftlang/swift-corelibs-foundation#5171

This makes it at least buildable on Android.