### PR TITLE
[6.1] CoreFoundation: adjust declaration of private SPI

### DIFF
--- a/Sources/CoreFoundation/CFRuntime.c
+++ b/Sources/CoreFoundation/CFRuntime.c
@@ -45,6 +45,10 @@ OBJC_EXPORT void *objc_destructInstance(id obj);
 #include <pathcch.h>
 #endif
 
+#if __HAS_DISPATCH__ && !TARGET_OS_MAC
+#include <dispatch/dispatch.h>
+#endif
+
 enum {
 // retain/release recording constants -- must match values
 // used by OA for now; probably will change in the future
@@ -1165,8 +1169,8 @@ CF_EXPORT
 
 CF_PRIVATE os_unfair_recursive_lock CFPlugInGlobalDataLock;
 
-#if __HAS_DISPATCH__
-extern void libdispatch_init();
+#if __HAS_DISPATCH__ && !TARGET_OS_MAC
+DISPATCH_EXPORT void libdispatch_init();
 #endif
 
 void __CFInitialize(void) {


### PR DESCRIPTION
The SPI declaration for `libdispatch_init` was not attribtued properly. The result of this omission was an improper reference to the function on Windows when disaptch is _not_ linked statically. Correct the declaration by re-using the `DISPATCH_EXPORT` macro to decorate the declaration with the appropriate DLLStorage as necessary.

This was caught by running the Foundation tests with SPM with a refactoring of the toolchain layout during the build.

(cherry picked from commit 853b68167d1ea012b732aa19eecebfbd9e3b10fd)

- **Explanation**: Correct the inline declaration for a libdispatch SPI.
- **Scope**: This changes the CPP declaration for the libdispatch SPI in just the implementation of a single translation unit in CoreFoundation. The resulting difference is limited to the Windows platform.
- **Issues**:
- **Original PRs**: https://github.com/swiftlang/swift-corelibs-foundation/pull/5181
- **Risk**: Very low risk, the declaration change is limited to Windows, where the generated reference would remain incorrect.
- **Testing**: Disassembly of the object file, validating the proper call sequence.
- **Reviewers**: The change was merged to unblock subsequent work on the Windows port.