### PR TITLE
[6.1] Process: unwrap the posix_spawnattr_t on Android

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -944,6 +944,12 @@ open class Process: NSObject, @unchecked Sendable {
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
 #endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
+#if os(Android)
+        guard var spawnAttrs else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno),
+                          userInfo: [NSURLErrorKey:self.executableURL!])
+        }
+#endif
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
 #if canImport(Darwin)
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT)))


### PR DESCRIPTION
This is required as while `posix_spawnattr_init` permits a nullable type, `posix_spawnattr_setflags` properly expects a non-null parameter. Unwrap the newly minted spawnattr or abort if the allocation failed.

Cherry pick commit https://github.com/swiftlang/swift-corelibs-foundation/pull/5179