### PR TITLE
[FreeBSD] Enable CFRunLoop support

### DIFF
--- a/Sources/CoreFoundation/CFRunLoop.c
+++ b/Sources/CoreFoundation/CFRunLoop.c
@@ -72,7 +72,7 @@ extern bool _dispatch_runloop_root_queue_perform_4CF(dispatch_queue_t queue);
 
 #if TARGET_OS_MAC
 typedef mach_port_t dispatch_runloop_handle_t;
-#elif defined(__linux__) || defined(__FreeBSD__)
+#elif defined(__linux__)
 typedef int dispatch_runloop_handle_t;
 #elif TARGET_OS_WIN32
 typedef HANDLE dispatch_runloop_handle_t;

--- a/Sources/CoreFoundation/CFRunLoop.c
+++ b/Sources/CoreFoundation/CFRunLoop.c
@@ -72,12 +72,14 @@ extern bool _dispatch_runloop_root_queue_perform_4CF(dispatch_queue_t queue);
 
 #if TARGET_OS_MAC
 typedef mach_port_t dispatch_runloop_handle_t;
-#elif defined(__linux__)
+#elif TARGET_OS_LINUX
 typedef int dispatch_runloop_handle_t;
+#elif TARGET_OS_BSD
+typedef uint64_t dispatch_runloop_handle_t;
 #elif TARGET_OS_WIN32
 typedef HANDLE dispatch_runloop_handle_t;
 #else
-typedef uint64_t dispatch_runloop_handle_t;
+#error "runloop support not implemented on this platform"
 #endif
 
 #if TARGET_OS_MAC

--- a/Sources/Foundation/RunLoop.swift
+++ b/Sources/Foundation/RunLoop.swift
@@ -120,7 +120,7 @@ open class RunLoop: NSObject {
     // Make sure we honor the override -- var currentCFRunLoop will do so on platforms where overrides are available.
 
     // TODO: This has been removed as public API in port to the package, because CoreFoundation cannot be available as both toolchain "CoreFoundation" and package "_CoreFoundation"
-    #if os(Linux) || os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(OpenBSD)
+    #if os(Linux) || os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(OpenBSD) || os(FreeBSD)
     internal var currentCFRunLoop: CFRunLoop { getCFRunLoop() }
 
     internal func getCFRunLoop() -> CFRunLoop {


### PR DESCRIPTION
This patch enables CFRunLoop for FreeBSD.
Related libdispatch PR: https://github.com/swiftlang/swift-corelibs-libdispatch/pull/861