### PR TITLE
Deprecate cString on non-Darwin (#3885)

### DIFF
--- a/Sources/Foundation/NSConcreteValue.swift
+++ b/Sources/Foundation/NSConcreteValue.swift
@@ -97,6 +97,7 @@ internal class NSConcreteValue : NSValue, @unchecked Sendable {
         value.copyMemory(from: self._storage, byteCount: self._size)
     }
     
+    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString instead")
     override var objCType : UnsafePointer<Int8> {
         return NSString(self._typeInfo.name).utf8String! // XXX leaky
     }

--- a/Sources/Foundation/NSSpecialValue.swift
+++ b/Sources/Foundation/NSSpecialValue.swift
@@ -97,6 +97,7 @@ internal class NSSpecialValue : NSValue, @unchecked Sendable {
         _value.encodeWithCoder(aCoder)
     }
     
+    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString instead")
     override var objCType : UnsafePointer<Int8> {
         let typeName = NSSpecialValue._objCTypeFromType(type(of: _value))
         return typeName!._bridgeToObjectiveC().utf8String! // leaky

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -903,6 +903,7 @@ extension NSString {
         }
     }
     
+    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString instead")
     public var utf8String: UnsafePointer<Int8>? {
         return _bytesInEncoding(self, .utf8, false, false, false)
     }
@@ -961,7 +962,8 @@ extension NSString {
                                           0, nil, 0, nil) == length
     }
    
-    public func cString(using encoding: UInt) -> UnsafePointer<Int8>? { 
+    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString(encodedAs:_) instead")
+    public func cString(using encoding: UInt) -> UnsafePointer<Int8>? {
         return _bytesInEncoding(self, String.Encoding(rawValue: encoding), false, false, false)
     }
     

--- a/Sources/Foundation/NSStringAPI.swift
+++ b/Sources/Foundation/NSStringAPI.swift
@@ -632,6 +632,7 @@ extension StringProtocol {
 
     /// Returns a representation of the string as a C string
     /// using a given encoding.
+    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString instead")
     public func cString(using encoding: String.Encoding) -> [CChar]? {
         return withExtendedLifetime(_ns) {
             (s: NSString) -> [CChar]? in

--- a/Sources/Foundation/NSStringAPI.swift
+++ b/Sources/Foundation/NSStringAPI.swift
@@ -632,7 +632,7 @@ extension StringProtocol {
 
     /// Returns a representation of the string as a C string
     /// using a given encoding.
-    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString instead")
+    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString(encodedAs:_) instead")
     public func cString(using encoding: String.Encoding) -> [CChar]? {
         return withExtendedLifetime(_ns) {
             (s: NSString) -> [CChar]? in

--- a/Sources/Foundation/NSStringAPI.swift
+++ b/Sources/Foundation/NSStringAPI.swift
@@ -632,11 +632,9 @@ extension StringProtocol {
 
     /// Returns a representation of the string as a C string
     /// using a given encoding.
-    @available(*, deprecated, message: "On platforms without Objective-C autorelease pools, use withCString(encodedAs:_) instead")
     public func cString(using encoding: String.Encoding) -> [CChar]? {
-        return withExtendedLifetime(_ns) {
-            (s: NSString) -> [CChar]? in
-            _persistCString(s.cString(using: encoding.rawValue))
+        return _ns._withCString(using: encoding.rawValue) {
+            _persistCString($0)
         }
     }
 

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -316,6 +316,12 @@ class TestNSString: LoopbackServerTest {
         XCTAssertNil(string)
     }
 
+    func test_cStringArray() {
+        let str = "abc"
+        let encoded = str.cString(using: .ascii)
+        XCTAssertEqual(encoded, [97, 98, 99, 0])
+    }
+
     func test_FromContentsOfURL() throws {
         throw XCTSkip("Test is flaky in CI: https://bugs.swift.org/browse/SR-10514")
         #if false


### PR DESCRIPTION
The extension on `String` to provide a C string works well enough on Darwin, when used with an `autoreleasepool { }`. However, on other platforms where we have no autorelease pools, it simply leaks. Even though this API is useful on Darwin, we should deprecate it in swift-corelibs-foundation because it has repeatedly been the source of some confusing behavior.

https://github.com/swiftlang/swift-corelibs-foundation/issues/3885