### PR TITLE
Set CMP0157 to OLD only for Windows hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,15 @@ if(POLICY CMP0156)
 endif()
 
 if(POLICY CMP0157)
-    # New Swift build model: improved incremental build performance and LSP support
-    cmake_policy(SET CMP0157 NEW)
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND CMAKE_SYSTEM_NAME STREQUAL Android)
+        # CMP0157 causes swift-collections to fail to compile when targetting
+        # Android on Windows due to swift-driver not being present during the
+        # toolchain build. Disable it for now.
+        cmake_policy(SET CMP0157 OLD)
+    else()
+        # New Swift build model: improved incremental build performance and LSP support
+        cmake_policy(SET CMP0157 NEW)
+    endif()
 endif()
 
 if (NOT DEFINED CMAKE_C_COMPILER)


### PR DESCRIPTION
  - **Explanation**:
    There is no early swift-driver build for the Windows toolchain. As a result, swift-collections fails to build properly when CMP0157 is set to NEW due to object files not being generated.

    This sets CMP0157 to OLD when targetting Android until the early swift-driver is available on Windows.
  - **Scope**:
    The changes are limited to the Android build on Windows.
  - **Issues**:
    swiftlang/swift-foundation#1222
  - **Original PRs**:
    #5180
  - **Risk**:
    Very low.
  - **Testing**:
    Fixes the Swift CI 6.1 build.
  - **Reviewers**:
    @finagolfin