### PR TITLE
Add -z,origin linker flag on OpenBSD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,12 @@ else()
         "/clang:-fcf-runtime-abi=swift")
 endif()
 
+set(CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
+set(CMAKE_INSTALL_RPATH "$ORIGIN")
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD|DragonFlyBSD")
+    add_link_options("LINKER:-z,origin")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     list(APPEND _Foundation_common_build_flags
         "-DDEBUG")

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -164,10 +164,6 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
 
-set_target_properties(Foundation PROPERTIES
-    INSTALL_RPATH "$ORIGIN"
-    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
-
 if(dispatch_FOUND)
     set_target_properties(Foundation PROPERTIES
         BUILD_RPATH "$<TARGET_FILE_DIR:swiftDispatch>")

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -73,10 +73,6 @@ if(NOT BUILD_SHARED_LIBS)
 
 endif()
 
-set_target_properties(FoundationNetworking PROPERTIES
-    INSTALL_RPATH "$ORIGIN"
-    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
-
 if(LINKER_SUPPORTS_BUILD_ID)
   target_link_options(FoundationNetworking PRIVATE "LINKER:--build-id=sha1")
 endif()

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -46,10 +46,6 @@ if(NOT BUILD_SHARED_LIBS)
 
 endif()
 
-set_target_properties(FoundationXML PROPERTIES
-    INSTALL_RPATH "$ORIGIN"
-    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
-
 if(LINKER_SUPPORTS_BUILD_ID)
   target_link_options(FoundationXML PRIVATE "LINKER:--build-id=sha1")
 endif()

--- a/Sources/plutil/CMakeLists.txt
+++ b/Sources/plutil/CMakeLists.txt
@@ -19,8 +19,7 @@ target_link_libraries(plutil PRIVATE
 	Foundation)
 
 set_target_properties(plutil PROPERTIES
-	INSTALL_RPATH "$ORIGIN/../lib/swift/${SWIFT_SYSTEM_NAME}"
-    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
+	INSTALL_RPATH "$ORIGIN/../lib/swift/${SWIFT_SYSTEM_NAME}")
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS plutil)
 install(TARGETS plutil


### PR DESCRIPTION
This is required for $ORIGIN rpath processing here (without having to fiddle with workarounds like LD_LIBRARY_PATH).