### PR TITLE
[wasm] Gate atomic write option usages behind platform check

### DIFF
--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -433,10 +433,13 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 #if os(WASI)
         // WASI does not have permission concept
         let permissions: Int? = nil
+        // ReadingOptions.atomic won't be specified on WASI as it's marked unavailable
+        var atomicWrite: Bool { false }
 #else
         let permissions = try? fm.attributesOfItem(atPath: path)[.posixPermissions] as? Int
+        let atomicWrite = writeOptionsMask.contains(.atomic)
 #endif
-        if writeOptionsMask.contains(.atomic) {
+        if atomicWrite {
             let (newFD, auxFilePath) = try _NSCreateTemporaryFile(path)
             let fh = FileHandle(fileDescriptor: newFD, closeOnDealloc: true)
             do {
@@ -487,22 +490,38 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
     /// Writes the data object's bytes to the file specified by a given path.
     /// NOTE: the 'atomically' flag is ignored if the url is not of a type the supports atomic writes
+    #if os(WASI)
+    @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
+    #endif
     open func write(toFile path: String, atomically useAuxiliaryFile: Bool) -> Bool {
+        #if os(WASI)
+        // WASI does not support atomic file-writing as it does not have temporary directories
+        return false
+        #else
         do {
             try write(toFile: path, options: useAuxiliaryFile ? .atomic : [])
         } catch {
             return false
         }
         return true
+        #endif
     }
 
     /// Writes the data object's bytes to the location specified by a given URL.
     /// NOTE: the 'atomically' flag is ignored if the url is not of a type the supports atomic writes
+    #if os(WASI)
+    @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
+    #endif
     open func write(to url: URL, atomically: Bool) -> Bool {
+        #if os(WASI)
+        // WASI does not support atomic file-writing as it does not have temporary directories
+        return false
+        #else
         if url.isFileURL {
             return write(toFile: url.path, atomically: atomically)
         }
         return false
+        #endif
     }
 
     ///    Writes the data object's bytes to the location specified by a given URL.

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1266,16 +1266,29 @@ extension NSString {
         data = mData
     }
     
+    #if os(WASI)
+    @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
+    #endif
     internal func _writeTo(_ url: URL, _ useAuxiliaryFile: Bool, _ enc: UInt) throws {
+        #if os(WASI)
+        throw CocoaError(.featureUnsupported)
+        #else
         var data = Data()
         try _getExternalRepresentation(&data, url, enc)
         try data.write(to: url, options: useAuxiliaryFile ? .atomic : [])
+        #endif
     }
     
+    #if os(WASI)
+    @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
+    #endif
     public func write(to url: URL, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
         try _writeTo(url, useAuxiliaryFile, enc)
     }
     
+    #if os(WASI)
+    @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
+    #endif
     public func write(toFile path: String, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
         try _writeTo(URL(fileURLWithPath: path), useAuxiliaryFile, enc)
     }


### PR DESCRIPTION
`Data.WritingOptions.atomic` is now unavailable on WASI https://github.com/swiftlang/swift-foundation/pull/992, so we need to gate them behind platform checks