### PR TITLE
Avoid implicitly linking RegexBuilder symbol

### DIFF
--- a/Sources/plutil/PLUContext_KeyPaths.swift
+++ b/Sources/plutil/PLUContext_KeyPaths.swift
@@ -14,7 +14,8 @@ extension String {
     /// Key paths can contain a `.`, but it must be escaped with a backslash `\.`. This function splits up a keypath, honoring the ability to escape a `.`.
     internal func escapedKeyPathSplit() -> [String] {
         let escapesReplaced = self.replacing("\\.", with: "A_DOT_WAS_HERE")
-        let split = escapesReplaced.split(separator: ".", omittingEmptySubsequences: false)
+        // Explicitly specify Character(".") to avoid accidentally using an implicit RegexBuilder overload
+        let split = escapesReplaced.split(separator: Character("."), omittingEmptySubsequences: false)
         return split.map { $0.replacingOccurrences(of: "A_DOT_WAS_HERE", with: ".") }
     }
 }


### PR DESCRIPTION
Recently, `FoundationEssentials` began importing the `RegexBuilder` module. While it's an `internal` import, since we don't have the `MemberImportVisibility` feature flag enabled, this import affected overload resolution of this call to `split`. Eventually, we should enable that feature flag to avoid these types of issues, but for now we make the argument explicitly `Character` to pick the stdlib overload instead of the `RegexBuilder` overload to fix linking failures.