### PR TITLE
Add UserDefaults.setStandardUserDefaults for Android

### DIFF
--- a/Sources/Foundation/UserDefaults.swift
+++ b/Sources/Foundation/UserDefaults.swift
@@ -90,7 +90,14 @@ open class UserDefaults: NSObject {
     }
     
     open class func resetStandardUserDefaults() {}
-    
+
+    #if os(Android)
+    /// Provide a custom implementation of `UserDefaults.standard` for platform integration.
+    open class func setStandardUserDefaults(_ defaults: UserDefaults) {
+        sharedDefaults = defaults
+    }
+    #endif
+
     public convenience override init() {
         self.init(suiteName: nil)!
     }


### PR DESCRIPTION
This PR adds `UserDefaults.setStandardUserDefaults(UserDefaults)` to provide the ability for a platform to override the standard defaults.

The existing Linux-specific defaults system doesn't work well on Android, whose "defaults" system are handled by the [SharedPreferences](https://developer.android.com/reference/android/content/SharedPreferences) Java class in the Android SDK. Rather than adding a JNI bridge here just for an Android-specific implementation, this PR takes the simpler route of just exposing the ability to override the standard user defaults with a public setter, which can be called at initialization time.