### PR TITLE
Instead of crashing with unknown types in print, use description

### DIFF
--- a/Sources/plutil/PLUContext.swift
+++ b/Sources/plutil/PLUContext.swift
@@ -772,7 +772,9 @@ struct PrintCommand {
             let description = number.description
             result.append("\(description)\n")
         } else {
-            throw PLUContextError.argument("Unknown property list type")
+            // Use a generic description
+            result.append(String(describing: value))
+            result.append("\n")
         }
         return result
     }


### PR DESCRIPTION
On Darwin, `plutil -p` can print keyed archiver archives. They contain `UUID`, which is a not a property list type, so `plutil` special cases them for ease of use.

Instead of throwing when we hit an unknown type, simply print a description - which is basically what the Objective-C implementation used to do.