### PR TITLE
Fix ptrauth C++ module include issue between extern

### DIFF
--- a/Sources/CoreFoundation/include/CFBase.h
+++ b/Sources/CoreFoundation/include/CFBase.h
@@ -669,6 +669,8 @@ CF_IMPLICIT_BRIDGING_DISABLED
 CF_EXPORT
 CFTypeRef CFMakeCollectable(CFTypeRef cf) CF_AUTOMATED_REFCOUNT_UNAVAILABLE;
 
+CF_EXTERN_C_END
+
 #if DEPLOYMENT_RUNTIME_SWIFT
 
 #if TARGET_RT_64_BIT
@@ -695,8 +697,6 @@ CFTypeRef CFMakeCollectable(CFTypeRef cf) CF_AUTOMATED_REFCOUNT_UNAVAILABLE;
 #else
 #define __ptrauth_cf_objc_isa_pointer
 #endif
-
-CF_EXTERN_C_END
 
 #endif /* ! __COREFOUNDATION_CFBASE__ */
 


### PR DESCRIPTION
Fix “error: import of C++ module 'ptrauth' appears within extern "C" language linkage specification”

LLVM upstream makes  ptrauth  a module on this commit https://github.com/swiftlang/llvm-project/commit/0481f049c37029d829dbc0c0cc5d1ee71c6d1c9a.

Swift 6.1 release introduced such change into the toolchain.

Close #5211