### PR TITLE
[6.2] Fix ptrauth C++ module include issue between extern

### DIFF
--- a/Sources/CoreFoundation/include/CFBase.h
+++ b/Sources/CoreFoundation/include/CFBase.h
@@ -669,6 +669,8 @@ CF_IMPLICIT_BRIDGING_DISABLED
 CF_EXPORT
 CFTypeRef CFMakeCollectable(CFTypeRef cf) CF_AUTOMATED_REFCOUNT_UNAVAILABLE;
 
+CF_EXTERN_C_END
+
 #if DEPLOYMENT_RUNTIME_SWIFT
 
 #if TARGET_RT_64_BIT
@@ -695,8 +697,6 @@ CFTypeRef CFMakeCollectable(CFTypeRef cf) CF_AUTOMATED_REFCOUNT_UNAVAILABLE;
 #else
 #define __ptrauth_cf_objc_isa_pointer
 #endif
-
-CF_EXTERN_C_END
 
 #endif /* ! __COREFOUNDATION_CFBASE__ */
 


### PR DESCRIPTION
- **Explanation**: Fix a regression introduced when use CF here on Linux introduced by 6.1 release.
- **Scope**: header and module issue
- **Issues**: 5211
- **Original PRs**: #5212
- **Risk**: Low
- **Testing**: None
- **Reviewers**: @parkera
