### PR TITLE
Use a regular downcast instead of an unsafe downcast for Error to NSError conversion

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -891,8 +891,8 @@ func _convertNSErrorToError(_ error: NSError?) -> Error {
 
 public // COMPILER_INTRINSIC
 func _convertErrorToNSError(_ error: Error) -> NSError {
-    if let object = _extractDynamicValue(error as Any) {
-        return unsafeDowncast(object, to: NSError.self)
+    if let object = _extractDynamicValue(error as Any), let asNS = object as? NSError {
+        return asNS
     } else {
         let domain: String
         let code: Int


### PR DESCRIPTION
Try suggestion in the bug and resolve #5221 .