### PR TITLE
build: define `CF_WINDOWS_EXECUTABLE_INITIALIZER`

### DIFF
--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -99,7 +99,8 @@ add_library(CoreFoundation STATIC
     CFWindowsUtilities.c
     CFXMLPreferencesDomain.c
     uuid.c)
-
+target_compile_definitions(CoreFoundation PRIVATE
+  $<$<AND:$<PLATFORM_ID:Windows>,$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>>:CF_WINDOWS_EXECUTABLE_INITIALIZER>)
 target_include_directories(CoreFoundation
     PUBLIC
         include


### PR DESCRIPTION
When building statically, define `CF_WINDOWS_EXECUTABLE_INITIALIZER` to ensure that the runtime constructor is registered and invoked properly. This is required to initialise CoreFoundation and `Foundation.Bundle`.