### PR TITLE
[Windows] Forward the WM_QUIT message so that it can be handled externally.

### DIFF
--- a/Sources/CoreFoundation/CFRunLoop.c
+++ b/Sources/CoreFoundation/CFRunLoop.c
@@ -3145,8 +3145,12 @@ static int32_t __CFRunLoopRun(CFRunLoopRef rl, CFRunLoopModeRef rlm, CFTimeInter
             } else {
                 MSG msg;
                 if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE | PM_NOYIELD)) {
-                    TranslateMessage(&msg);
-                    DispatchMessage(&msg);
+                    if (msg.message == WM_QUIT) {
+                        PostQuitMessage((int)msg.wParam);
+                    } else {
+                        TranslateMessage(&msg);
+                        DispatchMessage(&msg);
+                    }
                 }
             }
             


### PR DESCRIPTION
(On Windows)
If a WM_QUIT event is encountered inside that function (__CFRunLoopRun), it will be ignored and removed. This can be a problem for outer loops that are waiting for WM_QUIT messages.