### PR TITLE
build with 64-bit time_t on 32-bit platforms

### DIFF
--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -30,6 +30,12 @@ extension TimeInterval {
 #else
 extension timeval {
     internal init(_timeIntervalSince1970: TimeInterval) {
+        #if canImport(Glibc)
+        // support for 64-bit timestamps on 32-bit platforms; unfortunately
+        // suseconds_t is not an alias of the appropriate type, but time_t is
+        typealias suseconds_t = time_t
+        #endif
+
         let (integral, fractional) = modf(_timeIntervalSince1970)
         self.init(tv_sec: time_t(integral), tv_usec: suseconds_t(1.0e6 * fractional))
     }


### PR DESCRIPTION
It is good practice to build with 64-bit time_t/timeval on 32-bit platforms to avoid the Y2038 issue. This is the default when building on Yocto for armv7, for example. Unfortunately suseconds_t is not an alias to a type of the correct width (unlike time_t), so for Glibc make it a private alias of time_t to fix the build.