### PR TITLE
Add case within XML Node's name setter for DTDKind (#5230)

### DIFF
--- a/Sources/FoundationXML/XMLNode.swift
+++ b/Sources/FoundationXML/XMLNode.swift
@@ -357,6 +357,8 @@ open class XMLNode: NSObject, NSCopying {
                 _CFXMLNodeForceSetName(_xmlNode, newValue)
             case .namespace:
                 _CFXMLNamespaceSetPrefix(_xmlNode, newValue, Int64(newValue?.utf8.count ?? 0))
+            case .DTDKind:
+                _CFXMLNodeForceSetName(_xmlNode, newValue)
             default:
                 if let newName = newValue {
                     _CFXMLNodeSetName(_xmlNode, newName)


### PR DESCRIPTION
Fixes #5230 by force setting the name for XMLNodes when they're XMLDTDs as the regular _CFXMLNodeSetName function doesn't account for them with future versions of libxml2

