### PR TITLE
Move NotificationCenter to swift-foundation

### DIFF
--- a/Tests/Foundation/TestNotificationCenter.swift
+++ b/Tests/Foundation/TestNotificationCenter.swift
@@ -10,12 +10,6 @@
 final class NotificationCenterDummyObject : NSObject, Sendable { }
 
 class TestNotificationCenter : XCTestCase {
-    func test_defaultCenter() {
-        let defaultCenter1 = NotificationCenter.default
-        let defaultCenter2 = NotificationCenter.default
-        XCTAssertEqual(defaultCenter1, defaultCenter2)
-    }
-    
     func removeObserver(_ observer: NSObjectProtocol, notificationCenter: NotificationCenter) {
         guard let observer = observer as? NSObject else {
             return


### PR DESCRIPTION
This PR moves `NotificationCenter` into `swift-foundation`.

* `NotificationCenter` is now defined in `swift-foundation`, with some methods kept in `swift-corelibs-foundation` via `extension`. This has the result of removing the ability to override these methods, e.g. `addObserver(forName:object:queue:block)` cannot be `open` in an `extension`.
* `NotificationCenter` no longer conforms to `NSObject` in `swift-corelibs-foundation` due to the lack of `NSObject` in `swift-foundation`, where `NotificationCenter` is now defined, and the inability to add that inheritance retroactively in `swift-corelibs-foundation`.
* Core logic for `NotificationCenter` was moved to `swift-foundation` and is accessed via `@_spi(SwiftCorelibsFoundation) public` methods. This enables methods like `addObserver(forName:object:queue:block)` to remain in `swift-corelibs-foundation`.