### PR TITLE
[6.2] Use a regular downcast instead of an unsafe downcast for Error to NSError conversion (#5221) (#5222)

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -891,8 +891,8 @@ func _convertNSErrorToError(_ error: NSError?) -> Error {
 
 public // COMPILER_INTRINSIC
 func _convertErrorToNSError(_ error: Error) -> NSError {
-    if let object = _extractDynamicValue(error as Any) {
-        return unsafeDowncast(object, to: NSError.self)
+    if let object = _extractDynamicValue(error as Any), let asNS = object as? NSError {
+        return asNS
     } else {
         let domain: String
         let code: Int


### PR DESCRIPTION
- **Explanation**: Accessing `localizedDescription` on a class that conforms to `Error` but does not inherit from `NSError` causes a crash on Linux.
- **Scope**: Non-Darwin platforms only
- **Issue**: https://github.com/swiftlang/swift-corelibs-foundation/issues/5221
- **Original PR**: #5222
- **Risk**: Seems low to me and the current crash is definitely not desirable
- **Testing**: n/a 
- **Reviewer**: @jmschonfeld on https://github.com/swiftlang/swift-corelibs-foundation/pull/5222