### PR TITLE
Remove Decimal.pow() in favor of the one defined in FoundationEssentials

### DIFF
--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -39,10 +39,6 @@ extension Decimal : _ObjectiveCBridgeable {
 
 // MARK: - C Functions
 
-public func pow(_ x: Decimal, _ y: Int) -> Decimal {
-    _pow(x, y)
-}
-
 public func NSDecimalAdd(_ result: UnsafeMutablePointer<Decimal>, _ lhs: UnsafePointer<Decimal>, _ rhs: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError {
     _NSDecimalAdd(result, lhs, rhs, roundingMode)
 }


### PR DESCRIPTION
This PR depends on https://github.com/swiftlang/swift-foundation/pull/1471 (which exposes Decimal.pow() as a public API)

Resolves: https://github.com/swiftlang/swift-foundation/issues/1455