### PR TITLE
Add brotli as a dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,9 @@ if let environmentPath = Context.environment["CURL_INCLUDE_PATH"] {
 
 var curlLinkFlags: [LinkerSetting] = [
     .linkedLibrary("libcurl.lib", .when(platforms: [.windows])),
-    .linkedLibrary("zlibstatic.lib", .when(platforms: [.windows]))
+    .linkedLibrary("zlibstatic.lib", .when(platforms: [.windows])),
+    .linkedLibrary("brotlicommon.lib", .when(platforms: [.windows])),
+    .linkedLibrary("brotlidec.lib", .when(platforms: [.windows]))
 ]
 if let environmentPath = Context.environment["CURL_LIBRARY_PATH"] {
     curlLinkFlags.append(.unsafeFlags([
@@ -66,6 +68,11 @@ if let environmentPath = Context.environment["CURL_LIBRARY_PATH"] {
     ]))
 }
 if let environmentPath = Context.environment["ZLIB_LIBRARY_PATH"] {
+    curlLinkFlags.append(.unsafeFlags([
+        "-L\(environmentPath)"
+    ]))
+}
+if let environmentPath = Context.environment["BROTLI_LIBRARY_PATH"] {
     curlLinkFlags.append(.unsafeFlags([
         "-L\(environmentPath)"
     ]))

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -31,6 +31,18 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         }
     }
 
+    func test_dataTaskWithAcceptEncoding() async {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/accept-encoding"
+        let url = URL(string: urlString)!
+        let d = DataTask(with: expectation(description: "GET \(urlString): with a delegate"))
+        d.run(with: url)
+        waitForExpectations(timeout: 12)
+        if !d.error {
+            let supportedEncodings = d.capital.split(separator: ",").map { $0.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines ) }
+            XCTAssert(supportedEncodings.contains("br"), "test_dataTaskWithURLRequest returned an unexpected result")
+        }
+    }
+
     func test_dataTaskWithURLCompletionHandler() async {
         //shared session
         await dataTaskWithURLCompletionHandler(with: URLSession.shared)
@@ -249,6 +261,17 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/gzipped-response"
         let url = URL(string: urlString)!
         let d = DataTask(with: expectation(description: "GET \(urlString): gzipped response"))
+        d.run(with: url)
+        waitForExpectations(timeout: 12)
+        if !d.error {
+            XCTAssertEqual(d.capital, "Hello World!")
+        }
+    }
+
+    func test_brotliDataTask() async {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/brotli-response"
+        let url = URL(string: urlString)!
+        let d = DataTask(with: expectation(description: "GET \(urlString): brotli response"))
         d.run(with: url)
         waitForExpectations(timeout: 12)
         if !d.error {


### PR DESCRIPTION
(This is the 6.2 back port of https://github.com/swiftlang/swift-corelibs-foundation/pull/5251)

Add brotli as a dependency to enable brotli decoding for curl.

On Windows, only brotlicommon.lib and brotlidec.lib is linked.
brotlienc.lib is intentionally left out as curl does not need it. brotlienc.lib is also much larger in size (~3.8MB).