### PR TITLE
Add GitHub workflows, including testing linux

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,28 @@
+name: Pull request
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  tests:
+    name: Test (SwiftPM)
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
+    with:
+      linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
+      enable_windows_checks: false
+      enable_cross_pr_testing: true
+
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.13
+    with:
+      license_header_check_project_name: "Swift.org"
+      license_header_check_enabled: false
+      docs_check_enabled: false
+      format_check_enabled: false
+      unacceptable_language_check_enabled: false
+      api_breakage_check_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,28 @@
+name: Pull request
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  tests:
+    name: Test (SwiftPM)
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.15
+    with:
+      linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
+      enable_windows_checks: false
+      enable_cross_pr_testing: true
+
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.15
+    with:
+      license_header_check_project_name: "Swift.org"
+      license_header_check_enabled: false
+      docs_check_enabled: false
+      format_check_enabled: false
+      unacceptable_language_check_enabled: false
+      api_breakage_check_enabled: false


### PR DESCRIPTION
This is a straight copy of the current swift-foundation workflows, after removing the different CMake job and irrelevant macOS config.