### PR TITLE
FreeBSD: use eventfd and timerfd for CFRunloop

### DIFF
--- a/Sources/CoreFoundation/CFRunLoop.c
+++ b/Sources/CoreFoundation/CFRunLoop.c
@@ -72,7 +72,7 @@ extern bool _dispatch_runloop_root_queue_perform_4CF(dispatch_queue_t queue);
 
 #if TARGET_OS_MAC
 typedef mach_port_t dispatch_runloop_handle_t;
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || defined(__FreeBSD__)
 typedef int dispatch_runloop_handle_t;
 #elif TARGET_OS_BSD
 typedef uint64_t dispatch_runloop_handle_t;
@@ -110,11 +110,15 @@ DISPATCH_EXPORT void _dispatch_main_queue_callback_4CF(void * _Null_unspecified)
 #define mach_port_name_t HANDLE
 #define mach_port_t HANDLE
 
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || defined(__FreeBSD__)
 
 #include <dlfcn.h>
 #include <poll.h>
+#if defined(__FreeBSD__)
+#include <sys/event.h>
+#else
 #include <sys/epoll.h>
+#endif
 #include <sys/eventfd.h>
 #include <sys/timerfd.h>
 
@@ -411,11 +415,11 @@ static kern_return_t __CFPortSetRemove(__CFPort port, __CFPortSet portSet) {
     return KERN_SUCCESS;
 }
 
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || defined(__FreeBSD__)
 #define CFPORT_NULL -1
 #define MACH_PORT_NULL CFPORT_NULL
 
-// epoll file descriptor
+// epoll / kqueue file descriptor
 typedef int __CFPortSet;
 #define CFPORTSET_NULL -1
 
@@ -428,26 +432,44 @@ CF_INLINE void __CFPortFree(__CFPort port, __unused uintptr_t guard) {
 }
 
 CF_INLINE __CFPortSet __CFPortSetAllocate(void) {
+#if TARGET_OS_LINUX
     return epoll_create1(EPOLL_CLOEXEC);
+#else
+    return kqueue();
+#endif
 }
 
 CF_INLINE kern_return_t __CFPortSetInsert(__CFPort port, __CFPortSet portSet) {
     if (CFPORT_NULL == port) {
         return -1;
     }
+#if TARGET_OS_LINUX
     struct epoll_event event;
     memset(&event, 0, sizeof(event));
     event.data.fd = port;
     event.events = EPOLLIN|EPOLLET;
     
     return epoll_ctl(portSet, EPOLL_CTL_ADD, port, &event);
+#else
+    struct kevent event;
+    memset(&event, 0, sizeof(struct kevent));
+    EV_SET(&event, port, EVFILT_READ, EV_ADD | EV_ENABLE | EV_CLEAR | EV_RECEIPT, 0, 0, NULL);
+    return kevent(portSet, &event, 1, NULL, 0, NULL);
+#endif
 }
 
 CF_INLINE kern_return_t __CFPortSetRemove(__CFPort port, __CFPortSet portSet) {
     if (CFPORT_NULL == port) {
         return -1;
     }
+#if TARGET_OS_LINUX
     return epoll_ctl(portSet, EPOLL_CTL_DEL, port, NULL);
+#else
+    struct kevent event;
+    memset(&event, 0, sizeof(struct kevent));
+    EV_SET(&event, port, EVFILT_READ, EV_RECEIPT | EV_DELETE, 0, 0, NULL);
+    return kevent(portSet, &event, 1, NULL, 0, NULL);
+#endif
 }
 
 CF_INLINE void __CFPortSetFree(__CFPortSet portSet) {
@@ -473,8 +495,6 @@ typedef struct ___CFPortSet {
     int kq;
 } *__CFPortSet;
 #define CFPORTSET_NULL NULL
-
-#define TIMEOUT_INFINITY UINT64_MAX
 
 // Timers are not pipes; they are kevents on a parent kqueue.
 // We must flag these to differentiate them from pipes, but we have
@@ -643,76 +663,6 @@ CF_INLINE void __CFPortSetFree(__CFPortSet set) {
     free(set);
 }
 
-static int __CFPollFileDescriptors(struct pollfd *fds, nfds_t nfds, uint64_t timeout) {
-    uint64_t elapsed = 0;
-    uint64_t start = mach_absolute_time();
-    int result = 0;
-    while (1) {
-        struct timespec ts = {0};
-        struct timespec *tsPtr = &ts;
-        if (timeout == TIMEOUT_INFINITY) {
-            tsPtr = NULL;
-        } else if (elapsed < timeout) {
-            uint64_t delta = timeout - elapsed;
-            ts.tv_sec = delta / 1000000000UL;
-            ts.tv_nsec = delta % 1000000000UL;
-        }
-
-        result = ppoll(fds, 1, tsPtr, NULL);
-
-        if (result == -1 && errno == EINTR) {
-            uint64_t end = mach_absolute_time();
-            elapsed += (end - start);
-            start = end;
-        } else {
-            return result;
-        }
-    }
-}
-
-static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port, uint64_t timeout, __CFPort *livePort) {
-    __CFPort awokenPort = CFPORT_NULL;
-
-    if (port != CFPORT_NULL) {
-        int rfd = __CFPORT_UNPACK_R(port);
-        struct pollfd fdInfo = {
-            .fd = rfd,
-            .events = POLLIN,
-        };
-
-        ssize_t result = __CFPollFileDescriptors(&fdInfo, 1, timeout);
-        if (result == 0)
-            return false;
-
-        awokenPort = port;
-    } else {
-        struct kevent awake;
-        struct timespec timeout = {0, 0};
-
-        int r = kevent(set->kq, NULL, 0, &awake, 1, &timeout);
-
-        if (r == 0) {
-            return false;
-        }
-
-        if (awake.flags == EV_ERROR) {
-            return false;
-        }
-
-        if (awake.filter == EVFILT_READ) {
-            char x;
-            r = read(awake.ident, &x, 1);
-        }
-
-        awokenPort = (__CFPort)awake.udata;
-    }
-
-    if (livePort)
-        *livePort = awokenPort;
-
-    return true;
-}
-
 #else
 #error "CFPort* stubs for this platform must be implemented
 #endif
@@ -749,7 +699,7 @@ static uint32_t __CFSendTrivialMachMessage(mach_port_t port, uint32_t msg_id, CF
     __CFMachMessageCheckForAndDestroyUnsentMessage(result, &header);
     return result;
 }
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || defined(__FreeBSD__)
 
 static int mk_timer_create(void) {
     return timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC);
@@ -1137,7 +1087,7 @@ static CFRunLoopModeRef __CFRunLoopCopyMode(CFRunLoopRef rl, CFStringRef modeNam
     if (KERN_SUCCESS != ret) CRASH("*** Unable to insert timer port into port set. (%d) ***", ret);
 #endif
     rlm->_timerPort = CFPORT_NULL;
-#if TARGET_OS_BSD
+#if TARGET_OS_BSD && !defined(__FreeBSD__)
     rlm->_timerPort = mk_timer_create(rlm->_portSet);
 #else
     rlm->_timerPort = mk_timer_create();
@@ -2873,7 +2823,98 @@ static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet portSet, __CFPort o
     
     return true;
 }
+#elif TARGET_OS_BSD
 
+#define TIMEOUT_INFINITY UINT64_MAX
+
+static int __CFPollFileDescriptors(struct pollfd *fds, nfds_t nfds, uint64_t timeout) {
+    uint64_t elapsed = 0;
+    uint64_t start = mach_absolute_time();
+    int result = 0;
+    while (1) {
+        struct timespec ts = {0};
+        struct timespec *tsPtr = &ts;
+        if (timeout == TIMEOUT_INFINITY) {
+            tsPtr = NULL;
+        } else if (elapsed < timeout) {
+            uint64_t delta = timeout - elapsed;
+            ts.tv_sec = delta / 1000000000UL;
+            ts.tv_nsec = delta % 1000000000UL;
+        }
+
+        result = ppoll(fds, 1, tsPtr, NULL);
+
+        if (result == -1 && errno == EINTR) {
+            uint64_t end = mach_absolute_time();
+            elapsed += (end - start);
+            start = end;
+        } else {
+            return result;
+        }
+    }
+}
+
+static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port, uint64_t timeout, __CFPort *livePort) {
+    __CFPort awokenPort = CFPORT_NULL;
+
+    if (port != CFPORT_NULL) {
+        #if defined(__FreeBSD__)
+        struct pollfd fdInfo = {
+            .fd = port,
+            .events = POLLIN,
+        };
+        #else
+        int rfd = __CFPORT_UNPACK_R(port);
+        struct pollfd fdInfo = {
+            .fd = rfd,
+            .events = POLLIN,
+        };
+        #endif
+
+        ssize_t result = __CFPollFileDescriptors(&fdInfo, 1, timeout);
+        if (result == 0)
+            return false;
+
+        awokenPort = port;
+    } else {
+        struct kevent awake;
+        struct timespec timeout = {0, 0};
+
+        #if defined(__FreeBSD__)
+        int r = kevent(set, NULL, 0, &awake, 1, &timeout);
+        #else
+        int r = kevent(set->kq, NULL, 0, &awake, 1, &timeout);
+        #endif
+
+        if (r == 0) {
+            return false;
+        }
+
+        if (awake.flags == EV_ERROR) {
+            return false;
+        }
+
+        #if defined(__FreeBSD__)
+        uint64_t x;
+        if (awake.filter == EVFILT_READ) {
+            // both eventfd and timerfd reads a 64bit value
+            r = read((int)awake.ident, &x, 8);
+            awokenPort = (__CFPort)awake.ident;
+        }
+        #else
+        if (awake.filter == EVFILT_READ) {
+            char x;
+            r = read(awake.ident, &x, 1);
+        }
+        awokenPort = (__CFPort)awake.udata;
+        #endif
+    }
+
+    if (livePort)
+        *livePort = awokenPort;
+
+    return true;
+}
 #elif TARGET_OS_WIN32 || TARGET_OS_CYGWIN
 
 #define TIMEOUT_INFINITY INFINITE
@@ -3255,7 +3296,7 @@ static int32_t __CFRunLoopRun(CFRunLoopRef rl, CFRunLoopModeRef rlm, CFTimeInter
 		    (void)mach_msg(reply, MACH_SEND_MSG, reply->msgh_size, 0, MACH_PORT_NULL, 0, MACH_PORT_NULL);
 		    CFAllocatorDeallocate(kCFAllocatorSystemDefault, reply);
 		}
-#elif TARGET_OS_WIN32 || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN)
+#elif TARGET_OS_WIN32 || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN) || TARGET_OS_BSD
                 sourceHandledThisLoop = __CFRunLoopDoSource1(rl, rlm, rls) || sourceHandledThisLoop;
 #endif
             } else {
@@ -3410,7 +3451,7 @@ void CFRunLoopWakeUp(CFRunLoopRef rl) {
      * wakeup pending, since the queue length is 1. */
     ret = __CFSendTrivialMachMessage(rl->_wakeUpPort, 0, MACH_SEND_TIMEOUT, 0);
     if (ret != MACH_MSG_SUCCESS && ret != MACH_SEND_TIMED_OUT) CRASH("*** Unable to send message to wake up port. (%x) ***", ret);
-#elif TARGET_OS_LINUX && !TARGET_OS_CYGWIN
+#elif defined(__FreeBSD__) || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN)
     int ret;
     do {
         ret = eventfd_write(rl->_wakeUpPort, 1);

--- a/Sources/CoreFoundation/CFRunLoop.c
+++ b/Sources/CoreFoundation/CFRunLoop.c
@@ -72,7 +72,7 @@ extern bool _dispatch_runloop_root_queue_perform_4CF(dispatch_queue_t queue);
 
 #if TARGET_OS_MAC
 typedef mach_port_t dispatch_runloop_handle_t;
-#elif TARGET_OS_LINUX || defined(__FreeBSD__)
+#elif TARGET_OS_LINUX || TARGET_OS_FREEBSD
 typedef int dispatch_runloop_handle_t;
 #elif TARGET_OS_BSD
 typedef uint64_t dispatch_runloop_handle_t;
@@ -110,11 +110,11 @@ DISPATCH_EXPORT void _dispatch_main_queue_callback_4CF(void * _Null_unspecified)
 #define mach_port_name_t HANDLE
 #define mach_port_t HANDLE
 
-#elif TARGET_OS_LINUX || defined(__FreeBSD__)
+#elif TARGET_OS_LINUX || TARGET_OS_FREEBSD
 
 #include <dlfcn.h>
 #include <poll.h>
-#if defined(__FreeBSD__)
+#if TARGET_OS_FREEBSD
 #include <sys/event.h>
 #else
 #include <sys/epoll.h>
@@ -415,7 +415,7 @@ static kern_return_t __CFPortSetRemove(__CFPort port, __CFPortSet portSet) {
     return KERN_SUCCESS;
 }
 
-#elif TARGET_OS_LINUX || defined(__FreeBSD__)
+#elif TARGET_OS_LINUX || TARGET_OS_FREEBSD
 #define CFPORT_NULL -1
 #define MACH_PORT_NULL CFPORT_NULL
 
@@ -699,7 +699,7 @@ static uint32_t __CFSendTrivialMachMessage(mach_port_t port, uint32_t msg_id, CF
     __CFMachMessageCheckForAndDestroyUnsentMessage(result, &header);
     return result;
 }
-#elif TARGET_OS_LINUX || defined(__FreeBSD__)
+#elif TARGET_OS_LINUX || TARGET_OS_FREEBSD
 
 static int mk_timer_create(void) {
     return timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC);
@@ -1087,7 +1087,7 @@ static CFRunLoopModeRef __CFRunLoopCopyMode(CFRunLoopRef rl, CFStringRef modeNam
     if (KERN_SUCCESS != ret) CRASH("*** Unable to insert timer port into port set. (%d) ***", ret);
 #endif
     rlm->_timerPort = CFPORT_NULL;
-#if TARGET_OS_BSD && !defined(__FreeBSD__)
+#if TARGET_OS_BSD && !TARGET_OS_FREEBSD
     rlm->_timerPort = mk_timer_create(rlm->_portSet);
 #else
     rlm->_timerPort = mk_timer_create();
@@ -2745,7 +2745,7 @@ static int __CFPollFileDescriptors(struct pollfd *fds, nfds_t nfds, uint64_t tim
     int result = 0;
     while (1) {
         struct timespec ts = {0};
-        struct timespec *tsPtr = &ts;
+        struct timespec *tsPtr = &tst';
         if (timeout == TIMEOUT_INFINITY) {
             tsPtr = NULL;
             
@@ -2823,6 +2823,97 @@ static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet portSet, __CFPort o
     
     return true;
 }
+#elif TARGET_OS_FREEBSD
+
+#define TIMEOUT_INFINITY UINT64_MAX
+
+static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port, uint64_t timeout, __CFPort *livePort) {
+    __CFPort awokenPort = CFPORT_NULL;
+
+    uint64_t elapsed = 0;
+    uint64_t start = mach_absolute_time();
+    int r = 0;
+    struct kevent awake;
+    struct pollfd fdInfo = {
+        .fd = port,
+        .events = POLLIN
+    };
+
+    // roll our own loop here since if we ppoll() the kq first before calling
+    // kevent() (similar to epoll on Linux), we are racing the potential something
+    // else may have called kevent on the kq during this gap. so we use the kevent
+    // builtin timeout instead
+    while (1) {
+      struct timespec ts = {0};
+      struct timespec *tsPtr = &ts;
+      if (timeout == TIMEOUT_INFINITY) {
+        tsPtr = NULL;
+      } else if (elapsed < timeout) {
+        uint64_t delta = timeout - elapsed;
+        ts.tv_sec = delta / 1000000000UL;
+        ts.tv_nsec = delta % 1000000000UL;
+      }
+
+      if (port == CFPORT_NULL) {
+        r = kevent(set, NULL, 0, &awake, 1, tsPtr);
+      } else {
+        r = ppoll(&fdInfo, 1, tsPtr, NULL);
+      }
+
+      if (r == -1 && errno == EINTR) {
+        uint64_t end = mach_absolute_time();
+        elapsed += (end - start);
+        start = end;
+      } else if (r < 0) {
+        return false;
+      } else {
+        break;
+      }
+
+      // timeout has reach and fd still not available
+      if (elapsed >= timeout) {
+        return false;
+      }
+    }
+
+    if (port != CFPORT_NULL) {
+        awokenPort = port;
+    } else {
+
+        if (r == 0) {
+            return false;
+        }
+
+        if (awake.flags & EV_ERROR || awake.filter != EVFILT_READ) {
+            return false;
+        }
+
+        awokenPort = (__CFPort)awake.ident;
+    }
+
+    // Now we acknowledge the wakeup. awokenFd is an eventfd (or possibly a
+    // timerfd ?). In either case, we read an 8-byte integer, as per eventfd(2)
+    // and timerfd_create(2).
+    uint64_t value;
+
+    do {
+        r = read(awokenPort, &value, sizeof(value));
+    } while (r == -1 && errno == EINTR);
+
+    if (r == -1 && errno == EAGAIN) {
+        // Another thread stole the wakeup for this fd. (FIXME Can this actually
+        // happen?)
+        return false;
+    }
+
+    CFAssert2(r == sizeof(value), __kCFLogAssertion, "%s(): error %d from read(2) while acknowledging wakeup", __PRETTY_FUNCTION__, errno);
+
+    if (livePort)
+        *livePort = awokenPort;
+
+    return true;
+}
+
 #elif TARGET_OS_BSD
 
 #define TIMEOUT_INFINITY UINT64_MAX
@@ -2858,18 +2949,11 @@ static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port,
     __CFPort awokenPort = CFPORT_NULL;
 
     if (port != CFPORT_NULL) {
-        #if defined(__FreeBSD__)
-        struct pollfd fdInfo = {
-            .fd = port,
-            .events = POLLIN,
-        };
-        #else
         int rfd = __CFPORT_UNPACK_R(port);
         struct pollfd fdInfo = {
             .fd = rfd,
             .events = POLLIN,
         };
-        #endif
 
         ssize_t result = __CFPollFileDescriptors(&fdInfo, 1, timeout);
         if (result == 0)
@@ -2879,12 +2963,7 @@ static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port,
     } else {
         struct kevent awake;
         struct timespec timeout = {0, 0};
-
-        #if defined(__FreeBSD__)
-        int r = kevent(set, NULL, 0, &awake, 1, &timeout);
-        #else
         int r = kevent(set->kq, NULL, 0, &awake, 1, &timeout);
-        #endif
 
         if (r == 0) {
             return false;
@@ -2894,20 +2973,11 @@ static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port,
             return false;
         }
 
-        #if defined(__FreeBSD__)
-        uint64_t x;
-        if (awake.filter == EVFILT_READ) {
-            // both eventfd and timerfd reads a 64bit value
-            r = read((int)awake.ident, &x, 8);
-            awokenPort = (__CFPort)awake.ident;
-        }
-        #else
         if (awake.filter == EVFILT_READ) {
             char x;
             r = read(awake.ident, &x, 1);
         }
         awokenPort = (__CFPort)awake.udata;
-        #endif
     }
 
     if (livePort)
@@ -2915,6 +2985,7 @@ static Boolean __CFRunLoopServiceFileDescriptors(__CFPortSet set, __CFPort port,
 
     return true;
 }
+
 #elif TARGET_OS_WIN32 || TARGET_OS_CYGWIN
 
 #define TIMEOUT_INFINITY INFINITE
@@ -3451,7 +3522,7 @@ void CFRunLoopWakeUp(CFRunLoopRef rl) {
      * wakeup pending, since the queue length is 1. */
     ret = __CFSendTrivialMachMessage(rl->_wakeUpPort, 0, MACH_SEND_TIMEOUT, 0);
     if (ret != MACH_MSG_SUCCESS && ret != MACH_SEND_TIMED_OUT) CRASH("*** Unable to send message to wake up port. (%x) ***", ret);
-#elif defined(__FreeBSD__) || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN)
+#elif TARGET_OS_FREEBSD || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN)
     int ret;
     do {
         ret = eventfd_write(rl->_wakeUpPort, 1);
@@ -4329,7 +4400,7 @@ static CFStringRef __CFRunLoopObserverCopyDescription(CFTypeRef cf) {	/* DOES CA
     }
 #if TARGET_OS_WIN32
     result = CFStringCreateWithFormat(kCFAllocatorSystemDefault, NULL, CFSTR("<CFRunLoopObserver %p [%p]>{valid = %s, activities = 0x%x, repeats = %s, order = %d, callout = %p, context = %@}"), cf, CFGetAllocator(rlo), __CFIsValid(rlo) ? "Yes" : "No", rlo->_activities, __CFRunLoopObserverRepeats(rlo) ? "Yes" : "No", rlo->_order, rlo->_callout, contextDesc);    
-#elif TARGET_OS_MAC || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN)
+#elif TARGET_OS_MAC || (TARGET_OS_LINUX && !TARGET_OS_CYGWIN) || TARGET_OS_FREEBSD
     void *addr = rlo->_callout;
     Dl_info info;
     const char *name = (dladdr(addr, &info) && info.dli_saddr == addr && info.dli_sname) ? info.dli_sname : "???";

--- a/Sources/CoreFoundation/CFRunLoop.c
+++ b/Sources/CoreFoundation/CFRunLoop.c
@@ -2745,7 +2745,7 @@ static int __CFPollFileDescriptors(struct pollfd *fds, nfds_t nfds, uint64_t tim
     int result = 0;
     while (1) {
         struct timespec ts = {0};
-        struct timespec *tsPtr = &tst';
+        struct timespec *tsPtr = &ts;
         if (timeout == TIMEOUT_INFINITY) {
             tsPtr = NULL;
             

--- a/Sources/CoreFoundation/include/CFRunLoop.h
+++ b/Sources/CoreFoundation/include/CFRunLoop.h
@@ -107,7 +107,7 @@ typedef struct {
 typedef mach_port_t __CFPort;
 #elif TARGET_OS_WIN32 || TARGET_OS_CYGWIN
 typedef HANDLE __CFPort;
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || defined(__FreeBSD__)
 typedef int __CFPort; // eventfd/timerfd descriptor
 #elif TARGET_OS_BSD
 typedef uint64_t __CFPort;

--- a/Sources/CoreFoundation/include/CFTargetConditionals.h
+++ b/Sources/CoreFoundation/include/CFTargetConditionals.h
@@ -60,7 +60,8 @@
               TARGET_OS_WATCH           - Generated code will run under Apple Watch OS
            TARGET_OS_SIMULATOR      - Generated code will run under a simulator
            TARGET_OS_EMBEDDED       - Generated code for firmware
-       
+        TARGET_OS_BSD             - Generated code will run under *BSD
+            TARGET_OS_FREEBSD           - Generated code will run under FreeBSD
         TARGET_IPHONE_SIMULATOR   - DEPRECATED: Same as TARGET_OS_SIMULATOR
         TARGET_OS_NANO            - DEPRECATED: Same as TARGET_OS_WATCH
 
@@ -83,6 +84,7 @@
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_FREEBSD      0
 #define TARGET_OS_ANDROID      0
 #define TARGET_OS_CYGWIN       0
 #define TARGET_OS_WASI         0
@@ -91,6 +93,7 @@
 #define TARGET_OS_LINUX        1
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_FREEBSD      0
 #define TARGET_OS_ANDROID      1
 #define TARGET_OS_CYGWIN       0
 #define TARGET_OS_WASI         0
@@ -99,6 +102,7 @@
 #define TARGET_OS_LINUX        1
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_FREEBSD      0
 #define TARGET_OS_ANDROID      0
 #define TARGET_OS_CYGWIN       0
 #define TARGET_OS_WASI         0
@@ -107,6 +111,7 @@
 #define TARGET_OS_LINUX        1
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_FREEBSD      0
 #define TARGET_OS_ANDROID      0
 #define TARGET_OS_CYGWIN       1
 #define TARGET_OS_WASI         0
@@ -115,6 +120,16 @@
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      1
 #define TARGET_OS_BSD          0
+#define TARGET_OS_FREEBSD      0
+#define TARGET_OS_ANDROID      0
+#define TARGET_OS_CYGWIN       0
+#define TARGET_OS_WASI         0
+#elif __FreeBSD__
+#define TARGET_OS_DARWIN       0
+#define TARGET_OS_LINUX        0
+#define TARGET_OS_WINDOWS      0
+#define TARGET_OS_BSD          1
+#define TARGET_OS_FREEBSD      1
 #define TARGET_OS_ANDROID      0
 #define TARGET_OS_CYGWIN       0
 #define TARGET_OS_WASI         0
@@ -123,6 +138,7 @@
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          1
+#define TARGET_OS_FREEBSD      0
 #define TARGET_OS_ANDROID      0
 #define TARGET_OS_CYGWIN       0
 #define TARGET_OS_WASI         0
@@ -131,6 +147,7 @@
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_FREEBSD      0
 #define TARGET_OS_ANDROID      0
 #define TARGET_OS_CYGWIN       0
 #define TARGET_OS_WASI         1


### PR DESCRIPTION
FreeBSD currently use the generic kqueue / pipe2 mechanism from to crash if more more MAX_TIMERS are created (hardcoded to 16)

Since both eventfd and timerfd are available on FreeBSD, use that instead of pipe2 and EVFILT_TIMER

This is an ABI change on FreeBSD and also requires a libdispatch change: https://github.com/swiftlang/swift-corelibs-libdispatch/pull/957

### Motivation:

FreeBSD currently use the `EVFILT_TIMER` mechanism for timer, and `pipe2` as trigger from #3004. There are few
issues with this

- it only creating `MAX_TIMERS`(currently 16+1) timers, and led to crashes if extra timer are created. https://github.com/swiftlang/swift-corelibs-foundation/blob/761b621da93a856a48995efc29ed11028c283306/Sources/CoreFoundation/CFRunLoop.c#L522
https://github.com/swiftlang/swift-corelibs-foundation/blob/761b621da93a856a48995efc29ed11028c283306/Sources/CoreFoundation/CFRunLoop.c#L1146
- Even if we increase `MAX_TIMERS`, there's a system-wise limit (`kern.kq_calloutmax`) on how many timers allowed in kqueue (default is 4096 timers across the entire system). `timerfd` does not have such limitation 
- with the `pipe2` mechanism, `__CFPort` is encoded in a specific way to be able to both encode 2 file descriptors and a `EVFILT_TIMER`. since we're moving to `timerfd`, we can just that the `eventfd` branch instead. This also resolve a potential issue where in theory the runloop wakeup can stall if we write to a pipe with full buffer.

### Modifications:

Align FreeBSD runloop timer and awaking mechanism with Linux, using `timerfd` and `eventfd` instead of `EVFILT_TIMER` and `pipe2`

CFPortSet is still a kqueue 

### Result:

Running on FreeBSD not longer bounded by the `MAX_TIMERS` limit and system-wise `kern.kq_calloutmax` limit
